### PR TITLE
Use dune-configurator to support compiling on different operating systems

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,7 @@
  (synopsis "OCaml bindings for raylib")
  (depends
   dune
+  dune-configurator
   ctypes
   ppx_cstubs
   conf-cmake))

--- a/raylib.opam
+++ b/raylib.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/tjammer/raylib-ocaml"
 bug-reports: "https://github.com/tjammer/raylib-ocaml/issues"
 depends: [
   "dune" {>= "2.6"}
+  "dune-configurator"
   "ctypes"
   "ppx_cstubs"
   "conf-cmake"

--- a/raylib.opam
+++ b/raylib.opam
@@ -32,4 +32,3 @@ depexts: [
   ["libasound2-dev" "mesa-common-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev" "libglu1-mesa-dev"] {os-family = "debian"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "fedora"}
 ]
-available: [os = "linux" ]

--- a/raylib.opam.template
+++ b/raylib.opam.template
@@ -2,4 +2,3 @@ depexts: [
   ["libasound2-dev" "mesa-common-dev" "libx11-dev" "libxrandr-dev" "libxi-dev" "xorg-dev" "libgl1-mesa-dev" "libglu1-mesa-dev"] {os-family = "debian"}
   ["alsa-lib-devel" "mesa-libGL-devel" "libX11-devel" "libXrandr-devel" "libXi-devel" "libXcursor-devel" "libXinerama-devel"] {os-distribution = "fedora"}
 ]
-available: [os = "linux" ]

--- a/src/c/config/configure.ml
+++ b/src/c/config/configure.ml
@@ -13,8 +13,7 @@ let () =
         | Some "macosx" ->
             link ~flag:"-framework"
               [ "OpenGL"; "Cocoa"; "IOKit"; "CoreAudio"; "CoreVideo" ]
-        | Some ("mingw" | "mingw64" | "win32" | "win64" | "cygwin") ->
-            link [ "opengl32"; "gdi32"; "winmm"; "pthread" ]
+        | Some "mingw64" -> link [ "opengl32"; "gdi32"; "winmm"; "pthread" ]
         | Some ("netbsd" | "freebsd" | "openbsd" | "bsd" | "bsd_elf") ->
             link
               [

--- a/src/c/config/dune
+++ b/src/c/config/dune
@@ -1,3 +1,3 @@
 (executable
- (name generate)
+ (name configure)
  (libraries dune.configurator))

--- a/src/c/config/dune
+++ b/src/c/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name generate)
+ (libraries dune.configurator))

--- a/src/c/config/generate.ml
+++ b/src/c/config/generate.ml
@@ -1,0 +1,20 @@
+module C = Configurator.V1
+
+let rec link ?(flag = "-l") = function
+  | [] -> []
+  | lib :: libs -> "-cclib" :: (flag ^ " " ^ lib) :: link ~flag libs
+
+let () =
+  C.main ~name:"raylib" (fun c ->
+      let library_flags =
+        match C.ocaml_config_var c "system" with
+        | Some ("linux" | "linux_elf") ->
+            link [ "GL"; "m"; "pthread"; "dl"; "rt"; "X11" ]
+        | Some "macosx" ->
+            link ~flag:"-framework"
+              [ "OpenGL"; "Cocoa"; "IOKit"; "CoreAudio"; "CoreVideo" ]
+        | Some system -> C.die "unsupported system: %s" system
+        | None -> C.die "unsupported system"
+      in
+
+      C.Flags.write_sexp "library_flags.sexp" library_flags)

--- a/src/c/config/generate.ml
+++ b/src/c/config/generate.ml
@@ -15,6 +15,19 @@ let () =
               [ "OpenGL"; "Cocoa"; "IOKit"; "CoreAudio"; "CoreVideo" ]
         | Some ("mingw" | "mingw64" | "win32" | "win64" | "cygwin") ->
             link [ "opengl32"; "gdi32"; "winmm"; "pthread" ]
+        | Some ("netbsd" | "freebsd" | "openbsd" | "bsd" | "bsd_elf") ->
+            link
+              [
+                "GL";
+                "pthread";
+                "m";
+                "X11";
+                "Xrandr";
+                "Xinerama";
+                "Xi";
+                "Xxf86vm";
+                "Xcursor";
+              ]
         | Some system -> C.die "unsupported system: %s" system
         | None -> C.die "unsupported system"
       in

--- a/src/c/config/generate.ml
+++ b/src/c/config/generate.ml
@@ -13,6 +13,8 @@ let () =
         | Some "macosx" ->
             link ~flag:"-framework"
               [ "OpenGL"; "Cocoa"; "IOKit"; "CoreAudio"; "CoreVideo" ]
+        | Some ("mingw" | "mingw64" | "win32" | "win64" | "cygwin") ->
+            link [ "opengl32"; "gdi32"; "winmm"; "pthread" ]
         | Some system -> C.die "unsupported system: %s" system
         | None -> C.die "unsupported system"
       in

--- a/src/c/dune
+++ b/src/c/dune
@@ -45,15 +45,17 @@
      (run mkdir build))
     (chdir
      vendor/build
-     (run cmake -DBUILD_SHARED_LIBS=OFF -DBUILD_EXAMPLES=OFF
-       -DBUILD_GAMES=OFF -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..))
+     (run cmake -DBUILD_SHARED_LIBS=OFF -G "Unix Makefiles"
+       -DBUILD_EXAMPLES=OFF -DBUILD_GAMES=OFF -DWITH_PIC=ON
+       -DCMAKE_BUILD_TYPE=Release -Wno-dev ..))
     (chdir
      vendor
      (run cmake --build build -- -j 8))
     (chdir
      vendor/build
-     (run cmake -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=OFF -DBUILD_GAMES=OFF
-       -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..))
+     (run cmake -DBUILD_SHARED_LIBS=ON -G "Unix Makefiles"
+       -DBUILD_EXAMPLES=OFF -DBUILD_GAMES=OFF -DWITH_PIC=ON
+       -DCMAKE_BUILD_TYPE=Release -Wno-dev ..))
     (chdir
      vendor
      (run cmake --build build -- -j 8))))))
@@ -73,11 +75,11 @@
 (rule
  (deps
   (alias build-raylib))
- (targets libraylib.a dllraylib.so)
+ (targets libraylib.a dllraylib.dll)
  (enabled_if
-  (= %{system} macosx))
+  (= %{system} mingw64))
  (action
   (no-infer
    (progn
-    (copy vendor/build/src/libraylib.a libraylib.a)
-    (copy vendor/build/src/libraylib.dylib dllraylib.so)))))
+    (copy vendor/build/src/libraylib_static.a libraylib.a)
+    (copy vendor/build/src/libraylib.dll dllraylib.dll)))))

--- a/src/c/dune
+++ b/src/c/dune
@@ -88,7 +88,7 @@
     (copy vendor/src/raylib.dll dllraylib.dll)))))
 
 (rule
- (targets libraylib.a dllraylib.dll)
+ (targets libraylib.a dllraylib.so)
  (enabled_if
   (or
    (= %{system} netbsd)

--- a/src/c/dune
+++ b/src/c/dune
@@ -31,82 +31,60 @@
 (data_only_dirs vendor)
 
 (rule
- (alias build-raylib)
- (deps
-  (source_tree vendor))
- (action
-  (no-infer
-   (progn
-    (chdir
-     vendor
-     (run rm -r build))
-    (chdir
-     vendor
-     (run mkdir build))
-    (chdir
-     vendor/build
-     (run cmake -DBUILD_SHARED_LIBS=OFF -G "Unix Makefiles"
-       -DBUILD_EXAMPLES=OFF -DBUILD_GAMES=OFF -DWITH_PIC=ON
-       -DCMAKE_BUILD_TYPE=Release -Wno-dev ..))
-    (chdir
-     vendor
-     (run cmake --build build -- -j 8))
-    (chdir
-     vendor/build
-     (run cmake -DBUILD_SHARED_LIBS=ON -G "Unix Makefiles"
-       -DBUILD_EXAMPLES=OFF -DBUILD_GAMES=OFF -DWITH_PIC=ON
-       -DCMAKE_BUILD_TYPE=Release -Wno-dev ..))
-    (chdir
-     vendor
-     (run cmake --build build -- -j 8))))))
-
-(rule
- (deps
-  (alias build-raylib))
  (targets libraylib.a dllraylib.so)
  (enabled_if
   (or
    (= %{system} linux)
    (= %{system} linux_elf)))
+ (deps
+  (source_tree vendor)
+  linux.patch)
  (action
   (no-infer
    (progn
-    (copy vendor/build/src/libraylib.a libraylib.a)
-    (copy vendor/build/src/libraylib.so.3.0.0 dllraylib.so)))))
+    (run make -C vendor/src RAYLIB_LIBTYPE=STATIC -j 8)
+    (copy vendor/src/libraylib.a libraylib.a)
+    (run make -C vendor/src clean)
+    (run make -C vendor/src RAYLIB_LIBTYPE=SHARED -j 8)
+    (copy vendor/src/libraylib.so.3.0.0 dllraylib.so)))))
 
 (rule
- (deps
-  (alias build-raylib))
  (targets libraylib.a dllraylib.so)
  (enabled_if
   (= %{system} macosx))
+ (deps
+  (source_tree vendor))
  (action
   (no-infer
    (progn
-    (copy vendor/build/src/libraylib.a libraylib.a)
-    (copy vendor/build/src/libraylib.dylib dllraylib.so)))))
+    (run make -C vendor/src RAYLIB_LIBTYPE=STATIC -j 8)
+    (copy vendor/src/libraylib.a libraylib.a)
+    (run make -C vendor/src clean)
+    (run make -C vendor/src RAYLIB_LIBTYPE=SHARED -j 8)
+    (copy vendor/src/libraylib.3.0.0.dylib dllraylib.so)))))
 
 (rule
- (deps
-  (alias build-raylib))
  (targets libraylib.a dllraylib.dll)
  (enabled_if
-  (or
-   (= %{system} mingw)
-   (= %{system} mingw64)
-   (= %{system} win32)
-   (= %{system} win64)
-   (= %{system} cygwin)))
+  (= %{system} mingw64))
+ (deps
+  (source_tree vendor)
+  mingw64.patch)
  (action
   (no-infer
    (progn
-    (copy vendor/build/src/libraylib_static.a libraylib.a)
-    (copy vendor/build/src/libraylib.dll dllraylib.dll)))))
+    (run chmod +w vendor/src/Makefile)
+    (with-stdin-from
+     mingw64.patch
+     (run patch --binary -p1))
+    (run make -C vendor/src RAYLIB_LIBTYPE=STATIC -j 8)
+    (copy vendor/src/libraylib.a libraylib.a)
+    (run make -C vendor/src clean)
+    (run make -C vendor/src RAYLIB_LIBTYPE=SHARED -j 8)
+    (copy vendor/src/raylib.dll dllraylib.dll)))))
 
 (rule
- (deps
-  (alias build-raylib))
- (targets libraylib.a dllraylib.so)
+ (targets libraylib.a dllraylib.dll)
  (enabled_if
   (or
    (= %{system} netbsd)
@@ -114,8 +92,13 @@
    (= %{system} openbsd)
    (= %{system} bsd)
    (= %{system} bsd_elf)))
+ (deps
+  (source_tree vendor))
  (action
   (no-infer
    (progn
-    (copy vendor/build/src/libraylib.a libraylib.a)
-    (copy vendor/build/src/libraylib.so.3.0.0 dllraylib.so)))))
+    (run gmake -C vendor/src RAYLIB_LIBTYPE=STATIC -j 8)
+    (copy vendor/src/libraylib.a libraylib.a)
+    (run gmake -C vendor/src clean)
+    (run gmake -C vendor/src RAYLIB_LIBTYPE=SHARED -j 8)
+    (copy vendor/src/libraylib.3.0.0.so dllraylib.so)))))

--- a/src/c/dune
+++ b/src/c/dune
@@ -65,7 +65,9 @@
   (alias build-raylib))
  (targets libraylib.a dllraylib.so)
  (enabled_if
-  (= %{system} linux))
+  (or
+   (= %{system} linux)
+   (= %{system} linux_elf)))
  (action
   (no-infer
    (progn
@@ -75,11 +77,45 @@
 (rule
  (deps
   (alias build-raylib))
+ (targets libraylib.a dllraylib.so)
+ (enabled_if
+  (= %{system} macosx))
+ (action
+  (no-infer
+   (progn
+    (copy vendor/build/src/libraylib.a libraylib.a)
+    (copy vendor/build/src/libraylib.dylib dllraylib.so)))))
+
+(rule
+ (deps
+  (alias build-raylib))
  (targets libraylib.a dllraylib.dll)
  (enabled_if
-  (= %{system} mingw64))
+  (or
+   (= %{system} mingw)
+   (= %{system} mingw64)
+   (= %{system} win32)
+   (= %{system} win64)
+   (= %{system} cygwin)))
  (action
   (no-infer
    (progn
     (copy vendor/build/src/libraylib_static.a libraylib.a)
     (copy vendor/build/src/libraylib.dll dllraylib.dll)))))
+
+(rule
+ (deps
+  (alias build-raylib))
+ (targets libraylib.a dllraylib.so)
+ (enabled_if
+  (or
+   (= %{system} netbsd)
+   (= %{system} freebsd)
+   (= %{system} openbsd)
+   (= %{system} bsd)
+   (= %{system} bsd_elf)))
+ (action
+  (no-infer
+   (progn
+    (copy vendor/build/src/libraylib.a libraylib.a)
+    (copy vendor/build/src/libraylib.so.3.0.0 dllraylib.so)))))

--- a/src/c/dune
+++ b/src/c/dune
@@ -42,6 +42,10 @@
  (action
   (no-infer
    (progn
+    (run chmod +w vendor/src/config.h)
+    (with-stdin-from
+     linux.patch
+     (run patch --binary -p1))
     (run make -C vendor/src RAYLIB_LIBTYPE=STATIC -j 8)
     (copy vendor/src/libraylib.a libraylib.a)
     (run make -C vendor/src clean)

--- a/src/c/dune
+++ b/src/c/dune
@@ -8,10 +8,15 @@
   (names c_generated_functions)
   (include_dirs %{project_root}/src/c/vendor/src))
  (libraries ctypes.stubs raylib_functions raylib_generated_constants)
- (c_library_flags
-  (-lX11 -lpthread)))
+ (library_flags
+  (:include library_flags.sexp)))
 
-; TODO use this sexp magic here for different systems
+(rule
+ (targets library_flags.sexp)
+ (deps
+  (:discover config/generate.exe))
+ (action
+  (run %{discover})))
 
 (rule
  (with-stdout-to
@@ -26,9 +31,9 @@
 (data_only_dirs vendor)
 
 (rule
+ (alias build-raylib)
  (deps
   (source_tree vendor))
- (targets libraylib.a dllraylib.so)
  (action
   (no-infer
    (progn
@@ -51,6 +56,28 @@
        -DWITH_PIC=ON -DCMAKE_BUILD_TYPE=Release -Wno-dev ..))
     (chdir
      vendor
-     (run cmake --build build -- -j 8))
+     (run cmake --build build -- -j 8))))))
+
+(rule
+ (deps
+  (alias build-raylib))
+ (targets libraylib.a dllraylib.so)
+ (enabled_if
+  (= %{system} linux))
+ (action
+  (no-infer
+   (progn
     (copy vendor/build/src/libraylib.a libraylib.a)
     (copy vendor/build/src/libraylib.so.3.0.0 dllraylib.so)))))
+
+(rule
+ (deps
+  (alias build-raylib))
+ (targets libraylib.a dllraylib.so)
+ (enabled_if
+  (= %{system} macosx))
+ (action
+  (no-infer
+   (progn
+    (copy vendor/build/src/libraylib.a libraylib.a)
+    (copy vendor/build/src/libraylib.dylib dllraylib.so)))))

--- a/src/c/dune
+++ b/src/c/dune
@@ -14,7 +14,7 @@
 (rule
  (targets library_flags.sexp)
  (deps
-  (:discover config/generate.exe))
+  (:discover config/configure.exe))
  (action
   (run %{discover})))
 

--- a/src/c/linux.patch
+++ b/src/c/linux.patch
@@ -1,0 +1,12 @@
+diff --binary -ur a/vendor/src/config.h b/vendor/src/config.h
+--- a/vendor/src/config.h
++++ b/vendor/src/config.h
+@@ -49,7 +49,7 @@
+ // Use busy wait loop for timing sync, if not defined, a high-resolution timer is setup and used
+ //#define SUPPORT_BUSY_WAIT_LOOP      1
+ // Use a half-busy wait loop, in this case frame sleeps for some time and runs a busy-wait-loop at the end
+-#define SUPPORT_HALFBUSY_WAIT_LOOP
++//#define SUPPORT_HALFBUSY_WAIT_LOOP
+ // Wait for events passively (sleeping while no events) instead of polling them actively every frame
+ //#define SUPPORT_EVENTS_WAITING      1
+ // Allow automatic screen capture of current screen pressing F12, defined in KeyCallback()

--- a/src/c/mingw64.patch
+++ b/src/c/mingw64.patch
@@ -1,0 +1,32 @@
+diff --binary -ur a/vendor/src/Makefile b/vendor/src/Makefile
+--- a/vendor/src/Makefile
++++ b/vendor/src/Makefile
+@@ -214,8 +214,8 @@
+ endif
+ 
+ # Define default C compiler and archiver to pack library
+-CC = gcc
+-AR = ar
++CC = x86_64-w64-mingw32-gcc
++AR = x86_64-w64-mingw32-ar
+ 
+ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+     ifeq ($(PLATFORM_OS),OSX)
+@@ -484,7 +484,7 @@
+         ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+             ifeq ($(PLATFORM_OS),WINDOWS)
+                 # TODO: Compile resource file raylib.dll.rc for linkage on raylib.dll generation
+-				$(CC) -shared -o $(RAYLIB_RELEASE_PATH)/raylib.dll $(OBJS) $(RAYLIB_RELEASE_PATH)/raylib.dll.rc.data -L$(RAYLIB_RELEASE_PATH) -static-libgcc -lopengl32 -lgdi32 -lwinmm -Wl,--out-implib,$(RAYLIB_RELEASE_PATH)/libraylib.dll.a
++				$(CC) -shared -o $(RAYLIB_RELEASE_PATH)/raylib.dll $(OBJS) -L$(RAYLIB_RELEASE_PATH) -static-libgcc -lopengl32 -lgdi32 -lwinmm -Wl,--out-implib,$(RAYLIB_RELEASE_PATH)/libraylibdll.a
+ 				@echo "raylib dynamic library (raylib.dll) and import library (libraylibdll.a) generated!"
+             endif
+             ifeq ($(PLATFORM_OS),LINUX)
+@@ -667,7 +667,7 @@
+ # Clean everything
+ clean:
+ ifeq ($(PLATFORM_OS),WINDOWS)
+-	del *.o $(RAYLIB_RELEASE_PATH)/libraylib.a $(RAYLIB_RELEASE_PATH)/libraylib.bc $(RAYLIB_RELEASE_PATH)/libraylib.so
++	rm -fv *.o $(RAYLIB_RELEASE_PATH)/libraylib.a $(RAYLIB_RELEASE_PATH)/libraylib.bc $(RAYLIB_RELEASE_PATH)/raylib.dll $(RAYLIB_RELEASE_PATH)/libraylibdll.a
+ else
+ 	rm -fv *.o $(RAYLIB_RELEASE_PATH)/libraylib.a $(RAYLIB_RELEASE_PATH)/libraylib.bc $(RAYLIB_RELEASE_PATH)/libraylib.so*
+ endif


### PR DESCRIPTION
This PR uses dune-configurator in order to choose the correct library flags for a given system, which allows the project to be compiled on non-linux operating systems.

The library flags are taken from the examples Makefile: https://github.com/raysan5/raylib/blob/103df6c40876a19c78a3380e3a9068e8ae7dc8dd/examples/Makefile#L304

I've added flags for macOS, Windows, and BSD operating systems. I have tested and confirmed that the project compiles on the `macos` and `mingw64` systems. Unfortunately, I couldn't test it on BSD because I don't have a FreeBSD machine and I have had no luck with virtual machines.