### PR TITLE
Remove SKIP_TEST env from .github/workflows/main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      SKIP_TEST: ${{ matrix.skip_test }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
As the title says. (This is not actually used.)