### PR TITLE
Update raygui version to 3.6

### DIFF
--- a/examples/gui/controls_test_suite.ml
+++ b/examples/gui/controls_test_suite.ml
@@ -22,8 +22,8 @@ type state = {
   list_view_ex_focus : int;
   list_view_ex_scroll_index : int;
   toggle_group_active : int;
-  multi_text_box_text : string;
-  mutable multi_text_box_edit_mode : bool;
+(*  multi_text_box_text : string; *)
+(*  mutable multi_text_box_edit_mode : bool; *)
   color_picker_val : Raylib.Color.t;
   slider_val : float;
   slider_bar_val : float;
@@ -54,8 +54,8 @@ let setup () =
     list_view_ex_focus = 0;
     list_view_ex_scroll_index = 0;
     toggle_group_active = 0;
-    multi_text_box_text = "Multi text box";
-    multi_text_box_edit_mode = false;
+(*    multi_text_box_text = "Multi text box"; *)
+(*    multi_text_box_edit_mode = false; *)
     color_picker_val = Raylib.Color.raywhite;
     slider_val = 0.0;
     slider_bar_val = 50.0;
@@ -127,18 +127,18 @@ let rec loop s =
       Raygui.group_box (Rectangle.create 25.0 310.0 125.0 150.0) "STATES";
       Raygui.lock ();
       Raygui.(
-        set_state ControlState.Normal;
+        set_state State.Normal;
         ignore (button (Rectangle.create 30.0 320.0 115.0 30.0) "NORMAL"));
       Raygui.(
-        set_state ControlState.Focused;
+        set_state State.Focused;
         ignore (button (Rectangle.create 30.0 355.0 115.0 30.0) "FOCUSED"));
       Raygui.(
-        set_state ControlState.Pressed;
+        set_state State.Pressed;
         ignore (button (Rectangle.create 30.0 390.0 115.0 30.0) "#15#PRESSED"));
       Raygui.(
-        set_state ControlState.Disabled;
+        set_state State.Disabled;
         ignore (button (Rectangle.create 30.0 425.0 115.0 30.0) "DISABLED"));
-      Raygui.set_state Raygui.ControlState.Normal;
+      Raygui.set_state Raygui.State.Normal;
       if not s.show_text_input_box then Raygui.unlock ();
 
       let rect = Rectangle.create 25.0 470.0 125.0 30.0 in
@@ -206,7 +206,7 @@ let rec loop s =
       in
 
       (* third column *)
-      let rect = Rectangle.create 320.0 25.0 225.0 140.0 in
+      (*let rect = Rectangle.create 320.0 25.0 225.0 140.0 in
       let multi_text_box_text =
         match
           Raygui.text_box_multi rect s.multi_text_box_text
@@ -216,10 +216,10 @@ let rec loop s =
             s.multi_text_box_edit_mode <- not s.multi_text_box_edit_mode;
             vl
         | vl, false -> vl
-      in
+      in*)
 
       let rect = Rectangle.create 320.0 185.0 196.0 192.0 in
-      let color_picker_val = Raygui.color_picker rect s.color_picker_val in
+      let color_picker_val = Raygui.color_picker rect "Color picker" s.color_picker_val in
 
       let rect = Rectangle.create 355.0 400.0 165.0 20.0 in
       let slider_val =
@@ -246,7 +246,7 @@ let rec loop s =
           draw_rectangle 0 0 (get_screen_width ()) (get_screen_height ())
             (fade Color.raywhite 0.8);
 
-          let text_input_text, res =
+          let text_input_text, _, res =
             Raygui.text_input_box
               (Rectangle.create
                  ((float_of_int (get_screen_width ()) /. 2.0) -. 120.0)
@@ -254,6 +254,7 @@ let rec loop s =
                  240.0 140.0)
               "Save file as..." "Introduce a save file name" "Ok;Cancel"
               s.text_input_text
+              100 0
           in
           if res = 0 || res = 1 || res = 2 then (text_input_text, false)
           else (text_input_text, show_text_input_box))
@@ -281,7 +282,7 @@ let rec loop s =
           list_view_ex_focus;
           list_view_ex_scroll_index;
           toggle_group_active;
-          multi_text_box_text;
+(*          multi_text_box_text; *)
           color_picker_val;
           slider_val;
           slider_bar_val;

--- a/src/c/dune
+++ b/src/c/dune
@@ -22,13 +22,17 @@
    (= %{system} elf)))
  (deps
   (source_tree vendor/raylib)
+  (source_tree vendor/raygui)
   enable_formats.patch
+  gui_scrollbar.patch
   (:discover apply_patch.exe))
  (action
   (no-infer
    (progn
     (run chmod +w vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run chmod +w vendor/raygui/src/raygui.h)
+    (run ./apply_patch.exe gui_scrollbar.patch)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
@@ -42,13 +46,17 @@
   (= %{system} macosx))
  (deps
   (source_tree vendor/raylib)
+  (source_tree vendor/raygui)
   enable_formats.patch
+  gui_scrollbar.patch
   (:discover apply_patch.exe))
  (action
   (no-infer
    (progn
     (run chmod +w vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run chmod +w vendor/raygui/src/raygui.h)
+    (run ./apply_patch.exe gui_scrollbar.patch)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
@@ -62,7 +70,9 @@
   (= %{system} mingw64))
  (deps
   (source_tree vendor/raylib)
+  (source_tree vendor/raygui)
   enable_formats.patch
+  gui_scrollbar.patch
   mingw64.patch
   (:discover apply_patch.exe))
  (action
@@ -70,6 +80,8 @@
    (progn
     (run chmod +w vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run chmod +w vendor/raygui/src/raygui.h)
+    (run ./apply_patch.exe gui_scrollbar.patch)
     (run chmod +w vendor/raylib/src/Makefile)
     (run ./apply_patch.exe mingw64.patch)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)
@@ -90,7 +102,9 @@
    (= %{system} bsd_elf)))
  (deps
   (source_tree vendor/raylib)
+  (source_tree vendor/raygui)
   enable_formats.patch
+  gui_scrollbar.patch
   freebsd.patch
   (:discover apply_patch.exe))
  (action
@@ -98,6 +112,8 @@
    (progn
     (run chmod +w vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run chmod +w vendor/raygui/src/raygui.h)
+    (run ./apply_patch.exe gui_scrollbar.patch)
     (run chmod +w vendor/raylib/src/Makefile)
     (run ./apply_patch.exe freebsd.patch)
     (run gmake -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)

--- a/src/c/gui_scrollbar.patch
+++ b/src/c/gui_scrollbar.patch
@@ -1,0 +1,28 @@
+diff --git a/vendor/raygui/src/raygui.h b/vendor/raygui/src/raygui.h
+--- a/vendor/raygui/src/raygui.h
++++ b/vendor/raygui/src/raygui.h
+@@ -591,6 +591,7 @@ RAYGUIAPI float GuiSliderBar(Rectangle bounds, const char *textLeft, const char
+ RAYGUIAPI float GuiProgressBar(Rectangle bounds, const char *textLeft, const char *textRight, float value, float minValue, float maxValue); // Progress Bar control, shows current progress value
+ RAYGUIAPI void GuiStatusBar(Rectangle bounds, const char *text);                                        // Status Bar control, shows info text
+ RAYGUIAPI void GuiDummyRec(Rectangle bounds, const char *text);                                         // Dummy control for placeholders
++RAYGUIAPI int GuiScrollBar(Rectangle bounds, int value, int minValue, int maxValue);   // Scroll bar control, used by GuiScrollPanel()
+ RAYGUIAPI Vector2 GuiGrid(Rectangle bounds, const char *text, float spacing, int subdivs);              // Grid control, returns mouse cell position
+ 
+ // Advance controls set
+@@ -1340,7 +1341,6 @@ static const char **GuiTextSplit(const char *text, char delimiter, int *count, i
+ static Vector3 ConvertHSVtoRGB(Vector3 hsv);                    // Convert color data from HSV to RGB
+ static Vector3 ConvertRGBtoHSV(Vector3 rgb);                    // Convert color data from RGB to HSV
+ 
+-static int GuiScrollBar(Rectangle bounds, int value, int minValue, int maxValue);   // Scroll bar control, used by GuiScrollPanel()
+ static void GuiTooltip(Rectangle controlRec);                   // Draw tooltip using control rec position
+ 
+ 
+@@ -4439,7 +4439,7 @@ static Vector3 ConvertHSVtoRGB(Vector3 hsv)
+ }
+ 
+ // Scroll bar control (used by GuiScrollPanel())
+-static int GuiScrollBar(Rectangle bounds, int value, int minValue, int maxValue)
++int GuiScrollBar(Rectangle bounds, int value, int minValue, int maxValue)
+ {
+     GuiState state = guiState;
+ 

--- a/src/c/raygui/fixed_types.ml
+++ b/src/c/raygui/fixed_types.ml
@@ -1,7 +1,7 @@
 open Raygui_types_generated
 
-module ControlState = struct
-  include ControlState
+module State = struct
+  include State
 
   let to_int x = Unsigned.UInt32.to_int Ctypes.(coerce t uint32_t x)
   let of_int i = Ctypes.(coerce uint32_t t (Unsigned.UInt32.of_int i))
@@ -93,13 +93,6 @@ end
 
 module ScrollBarProperty = struct
   include ScrollBarProperty
-
-  let to_int x = Unsigned.UInt32.to_int Ctypes.(coerce t uint32_t x)
-  let of_int i = Ctypes.(coerce uint32_t t (Unsigned.UInt32.of_int i))
-end
-
-module ScrollBarSide = struct
-  include ScrollBarSide
 
   let to_int x = Unsigned.UInt32.to_int Ctypes.(coerce t uint32_t x)
   let of_int i = Ctypes.(coerce uint32_t t (Unsigned.UInt32.of_int i))

--- a/src/c/raygui/functions.ml
+++ b/src/c/raygui/functions.ml
@@ -16,16 +16,19 @@ module Functions (F : Ctypes.FOREIGN) = struct
   (*  Unlock gui controls (global state) *)
   let unlock = foreign "GuiUnlock" (void @-> returning void)
 
+  (*  Get gui is locked (global state) *)
+  let is_locked = foreign "GuiIsLocked" (void @-> returning bool)
+
   (*  Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f *)
   let fade = foreign "GuiFade" (float @-> returning void)
 
   (*  Set gui state (global state) *)
   let set_state =
-    foreign "GuiSetState" (Constants.ControlState.t @-> returning void)
+    foreign "GuiSetState" (Constants.State.t @-> returning void)
 
   (*  Get gui state (global state) *)
   let get_state =
-    foreign "GuiGetState" (void @-> returning Constants.ControlState.t)
+    foreign "GuiGetState" (void @-> returning Constants.State.t)
 
   (* Font set/get functions *)
   (*  Set gui custom font (global state) *)
@@ -58,12 +61,15 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "GuiLine" (Raylib.Rectangle.t @-> string @-> returning void)
 
   (*  Panel control, useful to group controls *)
-  let _panel = foreign "GuiPanel" (Raylib.Rectangle.t @-> returning void)
+  let _panel = foreign "GuiPanel" (Raylib.Rectangle.t @-> string @-> returning void)
+
+  (*  Tab bar control *)
+  let _tab_bar = foreign "GuiTabBar" (Raylib.Rectangle.t @-> ptr string @-> int @-> ptr int @-> returning int)
 
   (*  Scroll Panel control *)
   let _scroll_panel =
     foreign "GuiScrollPanel"
-      (Raylib.Rectangle.t @-> Raylib.Rectangle.t @-> ptr Raylib.Vector2.t
+      (Raylib.Rectangle.t @-> string @-> Raylib.Rectangle.t @-> ptr Raylib.Vector2.t
       @-> returning Raylib.Rectangle.t)
 
   (* Basic controls set *)
@@ -121,11 +127,6 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "GuiTextBox"
       (Raylib.Rectangle.t @-> ptr char @-> int @-> bool @-> returning bool)
 
-  (*  Text Box control with multiple lines *)
-  let _text_box_multi =
-    foreign "GuiTextBoxMulti"
-      (Raylib.Rectangle.t @-> ptr char @-> int @-> bool @-> returning bool)
-
   (*  Slider control, returns selected value *)
   let _slider =
     foreign "GuiSlider"
@@ -160,7 +161,7 @@ module Functions (F : Ctypes.FOREIGN) = struct
   (*  Grid control *)
   let _grid =
     foreign "GuiGrid"
-      (Raylib.Rectangle.t @-> float @-> int @-> returning Raylib.Vector2.t)
+      (Raylib.Rectangle.t @-> string @-> float @-> int @-> returning Raylib.Vector2.t)
 
   (* Advance controls set *)
   (*  List View control, returns selected list item index *)
@@ -182,26 +183,26 @@ module Functions (F : Ctypes.FOREIGN) = struct
   (*  Text Input Box control, ask for text *)
   let _text_input_box =
     foreign "GuiTextInputBox"
-      (Raylib.Rectangle.t @-> string @-> string @-> string @-> ptr char
+      (Raylib.Rectangle.t @-> string @-> string @-> string @-> ptr char @-> int @-> ptr int
      @-> returning int)
 
   (*  Color Picker control (multiple color controls) *)
   let _color_picker =
     foreign "GuiColorPicker"
-      (Raylib.Rectangle.t @-> Raylib.Color.t @-> returning Raylib.Color.t)
+      (Raylib.Rectangle.t @-> string @-> Raylib.Color.t @-> returning Raylib.Color.t)
 
   (*  Color Panel control *)
   let _color_panel =
     foreign "GuiColorPanel"
-      (Raylib.Rectangle.t @-> Raylib.Color.t @-> returning Raylib.Color.t)
+      (Raylib.Rectangle.t @-> string @-> Raylib.Color.t @-> returning Raylib.Color.t)
 
   (*  Color Bar Alpha control *)
   let _color_bar_alpha =
-    foreign "GuiColorBarAlpha" (Raylib.Rectangle.t @-> float @-> returning float)
+    foreign "GuiColorBarAlpha" (Raylib.Rectangle.t @-> string @-> float @-> returning float)
 
   (*  Color Bar Hue control *)
   let _color_bar_hue =
-    foreign "GuiColorBarHue" (Raylib.Rectangle.t @-> float @-> returning float)
+    foreign "GuiColorBarHue" (Raylib.Rectangle.t @-> string @-> float @-> returning float)
 
   (* Styles loading functions *)
   (*  Load style file (.rgs) *)
@@ -210,4 +211,27 @@ module Functions (F : Ctypes.FOREIGN) = struct
   (*  Load style default over global style *)
   let load_style_default =
     foreign "GuiLoadStyleDefault" (void @-> returning void)
+
+  (* Tooltips management functions *)
+  (*  Enable tooltip (global state) *)
+  let enable_tooltip = foreign "GuiEnableTooltip" (void @-> returning void)
+
+  (*  Disable tooltip (global state) *)
+  let disable_tooltip = foreign "GuiDisableTooltip" (void @-> returning void)
+
+  (*  Set tooltip (global state) *)
+  let set_tooltip = foreign "GuiSetTooltip" (string @-> returning void)
+
+  (* Icons functionality *)
+  let icon_text = foreign "GuiIconText" (int @-> string @-> returning string)
+
+  (* Set icon scale (global state) *)
+  let set_icon_scale = foreign "GuiSetIconScale" (int @-> returning void)
+
+(*  let _get_icons = foreign "GuiGetIcons" (void @-> returning (ptr uint)) *)
+
+(*  let _load_icons = foreign "GuiLoadIcons" (string @-> bool @-> returning (ptr @@ ptr char)) *)
+
+  let _draw_icon = foreign "GuiDrawIcon" (int @-> int @-> int @-> int @-> Raylib.Color.t @-> returning void)
+
 end

--- a/src/c/raygui/types.ml
+++ b/src/c/raygui/types.ml
@@ -3,18 +3,18 @@ module Types (F : Ctypes.TYPE) = struct
 
   let typedef = true
 
-  module ControlState = struct
+  module State = struct
     type t = Normal | Focused | Pressed | Disabled
 
     let vals =
       [
-        (Normal, constant "GUI_STATE_NORMAL" int64_t);
-        (Focused, constant "GUI_STATE_FOCUSED" int64_t);
-        (Pressed, constant "GUI_STATE_PRESSED" int64_t);
-        (Disabled, constant "GUI_STATE_DISABLED" int64_t);
+        (Normal, constant "STATE_NORMAL" int64_t);
+        (Focused, constant "STATE_FOCUSED" int64_t);
+        (Pressed, constant "STATE_PRESSED" int64_t);
+        (Disabled, constant "STATE_DISABLED" int64_t);
       ]
 
-    let t = enum "GuiControlState" ~typedef vals
+    let t = enum "GuiState" ~typedef vals
   end
 
   module TextAlignment = struct
@@ -22,9 +22,9 @@ module Types (F : Ctypes.TYPE) = struct
 
     let vals =
       [
-        (Left, constant "GUI_TEXT_ALIGN_LEFT" int64_t);
-        (Center, constant "GUI_TEXT_ALIGN_CENTER" int64_t);
-        (Right, constant "GUI_TEXT_ALIGN_RIGHT" int64_t);
+        (Left, constant "TEXT_ALIGN_LEFT" int64_t);
+        (Center, constant "TEXT_ALIGN_CENTER" int64_t);
+        (Right, constant "TEXT_ALIGN_RIGHT" int64_t);
       ]
 
     let t = enum "GuiTextAlignment" ~typedef vals
@@ -162,24 +162,24 @@ module Types (F : Ctypes.TYPE) = struct
   end
 
   module ComboBoxProperty = struct
-    type t = Width | Padding
+    type t = Width | Spacing
 
     let vals =
       [
         (Width, constant "COMBO_BUTTON_WIDTH" int64_t);
-        (Padding, constant "COMBO_BUTTON_PADDING" int64_t);
+        (Spacing, constant "COMBO_BUTTON_SPACING" int64_t);
       ]
 
     let t = enum "GuiComboBoxProperty" ~typedef vals
   end
 
   module DropdownBoxProperty = struct
-    type t = Arrow_padding | Dropdown_items_padding
+    type t = Arrow_padding | Dropdown_items_spacing
 
     let vals =
       [
         (Arrow_padding, constant "ARROW_PADDING" int64_t);
-        (Dropdown_items_padding, constant "DROPDOWN_ITEMS_PADDING" int64_t);
+        (Dropdown_items_spacing, constant "DROPDOWN_ITEMS_SPACING" int64_t);
       ]
 
     let t = enum "GuiDropdownBoxProperty" ~typedef vals
@@ -188,28 +188,30 @@ module Types (F : Ctypes.TYPE) = struct
   module TextBoxProperty = struct
     type t =
       | Text_inner_padding
-      | Text_lines_padding
-      | Color_selected_fg
-      | Color_selected_bg
+      | Text_lines_spacing
+      | Text_alignment_vertical
+      | Text_multiline
+      | Text_wrap_mode
 
     let vals =
       [
         (Text_inner_padding, constant "TEXT_INNER_PADDING" int64_t);
-        (Text_lines_padding, constant "TEXT_LINES_PADDING" int64_t);
-        (Color_selected_fg, constant "COLOR_SELECTED_FG" int64_t);
-        (Color_selected_bg, constant "COLOR_SELECTED_BG" int64_t);
+        (Text_lines_spacing, constant "TEXT_LINES_SPACING" int64_t);
+        (Text_alignment_vertical, constant "TEXT_ALIGNMENT_VERTICAL" int64_t);
+        (Text_multiline, constant "TEXT_MULTILINE" int64_t);
+        (Text_wrap_mode, constant "TEXT_WRAP_MODE" int64_t);
       ]
 
     let t = enum "GuiTextBoxProperty" ~typedef vals
   end
 
   module SpinnerProperty = struct
-    type t = Width | Padding
+    type t = Width | Spacing
 
     let vals =
       [
         (Width, constant "SPIN_BUTTON_WIDTH" int64_t);
-        (Padding, constant "SPIN_BUTTON_PADDING" int64_t);
+        (Spacing, constant "SPIN_BUTTON_SPACING" int64_t);
       ]
 
     let t = enum "GuiSpinnerProperty" ~typedef vals
@@ -237,29 +239,17 @@ module Types (F : Ctypes.TYPE) = struct
     let t = enum "GuiScrollBarProperty" ~typedef vals
   end
 
-  module ScrollBarSide = struct
-    type t = Left | Right
-
-    let vals =
-      [
-        (Left, constant "SCROLLBAR_LEFT_SIDE" int64_t);
-        (Right, constant "SCROLLBAR_RIGHT_SIDE" int64_t);
-      ]
-
-    let t = enum "GuiScrollBarSide" ~typedef vals
-  end
-
   module ListViewProperty = struct
     type t =
       | List_items_height
-      | List_items_padding
+      | List_items_spacing
       | Scrollbar_width
       | Scrollbar_side
 
     let vals =
       [
         (List_items_height, constant "LIST_ITEMS_HEIGHT" int64_t);
-        (List_items_padding, constant "LIST_ITEMS_PADDING" int64_t);
+        (List_items_spacing, constant "LIST_ITEMS_SPACING" int64_t);
         (Scrollbar_width, constant "SCROLLBAR_WIDTH" int64_t);
         (Scrollbar_side, constant "SCROLLBAR_SIDE" int64_t);
       ]
@@ -293,7 +283,7 @@ module Types (F : Ctypes.TYPE) = struct
     let t : t Ctypes.structure typ = structure "GuiStyleProp"
     let control_id = field t "controlId" ushort
     let property_id = field t "propertyId" ushort
-    let property_value = field t "propertyValue" int
+    let property_value = field t "propertyValue" uint
     let () = seal t
   end
 end

--- a/src/raygui/functions.ml
+++ b/src/raygui/functions.ml
@@ -14,9 +14,14 @@ let window_box bx = _window_box @@ to_struct bx
 let group_box bx = _group_box @@ to_struct bx
 let line bx = _line @@ to_struct bx
 let panel bx = _panel @@ to_struct bx
+let tab_bar bx text count active =
+  let text_ptr = Raylib.ptr_of_string text in
+  let active_ptr = Raylib.ptr_of_int active in
+  let rt = _tab_bar (to_struct bx) text_ptr count active_ptr in
+  (Ctypes.(!@text_ptr), Ctypes.(!@active_ptr), rt)
 
-let scroll_panel a b c =
-  _scroll_panel (to_struct a) (to_struct b) (to_struct_ptr c) |> Raylib.to_ctyp
+let scroll_panel a s b c =
+  _scroll_panel (to_struct a) s (to_struct b) (to_struct_ptr c) |> Raylib.to_ctyp
 
 let label bx = _label @@ to_struct bx
 let button bx = _button @@ to_struct bx
@@ -70,7 +75,7 @@ let text_box rct txt state =
   in
   (str, rt)
 
-let text_box_multi rct txt state =
+(*let text_box_multi rct txt state =
   let open Ctypes in
   let str_arr = CArray.of_string txt in
   let rt =
@@ -87,7 +92,7 @@ let text_box_multi rct txt state =
     | Some last -> String.sub str 0 last
     | None -> str
   in
-  (str, rt)
+  (str, rt)*)
 
 let slider rct label txt value ~min ~max =
   _slider (to_struct rct) label txt value min max
@@ -101,7 +106,7 @@ let progress_bar rct label txt value ~min ~max =
 let status_bar rct = _status_bar @@ to_struct rct
 let dummy_rec rct = _dummy_rec @@ to_struct rct
 let scroll_bar rct value ~min ~max = _scroll_bar (to_struct rct) value min max
-let grid rct b c = _grid (to_struct rct) b c |> Raylib.to_ctyp
+let grid rct s b c = _grid (to_struct rct) s b c |> Raylib.to_ctyp
 
 let list_view rct label index active =
   let vl_ptr = Raylib.ptr_of_int index in
@@ -121,19 +126,23 @@ let list_view_ex rct strings focus index active =
 
 let message_box rct = _message_box @@ to_struct rct
 
-let text_input_box rct title message buttons text =
+let text_input_box rct title message buttons text text_max_size secret_view_active =
   let open Ctypes in
   let str_arr = CArray.of_string text in
+  let sv_ptr = Raylib.ptr_of_int secret_view_active in
   let rt =
-    _text_input_box (to_struct rct) title message buttons (CArray.start str_arr)
+    _text_input_box (to_struct rct) title message buttons (CArray.start str_arr) text_max_size sv_ptr
   in
-  (String.init (CArray.length str_arr) (CArray.unsafe_get str_arr), rt)
+  (String.init (CArray.length str_arr) (CArray.unsafe_get str_arr), Ctypes.(!@sv_ptr), rt)
 
-let color_picker rct col =
-  _color_picker (to_struct rct) (to_struct col) |> Raylib.to_ctyp
+let color_picker rct s col =
+  _color_picker (to_struct rct) s (to_struct col) |> Raylib.to_ctyp
 
-let color_panel rct col =
-  _color_panel (to_struct rct) (to_struct col) |> Raylib.to_ctyp
+let color_panel rct s col =
+  _color_panel (to_struct rct) s (to_struct col) |> Raylib.to_ctyp
 
 let color_bar_alpha rct = _color_bar_alpha @@ to_struct rct
 let color_bar_hue rct = _color_bar_hue @@ to_struct rct
+
+let draw_icon icon_id pos_x pos_y pixel_size color =
+  _draw_icon icon_id pos_x pos_y pixel_size @@ to_struct color

--- a/src/raygui/raygui.ml
+++ b/src/raygui/raygui.ml
@@ -21,23 +21,24 @@ module CheckBox = struct
 end
 
 module ComboBox = struct
-  type t = [ `Width_combobox | `Padding_combobox ]
+  type t = [ `Width_combobox | `Spacing_combobox ]
 end
 
 module DropdownBox = struct
-  type t = [ `Arrow_padding | `Dropdown_items_padding ]
+  type t = [ `Arrow_padding | `Dropdown_items_spacing ]
 end
 
 module TextBox = struct
   type t =
     [ `Text_inner_padding
-    | `Text_lines_padding
-    | `Color_selected_fg
-    | `Color_selected_bg ]
+    | `Text_lines_spacing
+    | `Text_alignment_vertical
+    | `Text_multiline
+    | `Text_wrap_mode ]
 end
 
 module Spinner = struct
-  type t = [ `Width_spinner | `Padding_spinner ]
+  type t = [ `Width_spinner | `Spacing_spinner ]
 end
 
 module ScrollBar = struct
@@ -55,7 +56,7 @@ end
 module ListView = struct
   type t =
     [ `List_items_height
-    | `List_items_padding
+    | `List_items_spacing
     | `Scrollbar_width
     | `Scrollbar_side ]
 end
@@ -132,16 +133,17 @@ let prop_to_int = function
   | `Padding_progressbar -> ProgressBarProperty.(to_int Padding)
   | `Padding_checkbox -> CheckBoxProperty.(to_int Padding)
   | `Width_combobox -> ComboBoxProperty.(to_int Width)
-  | `Padding_combobox -> ComboBoxProperty.(to_int Padding)
+  | `Spacing_combobox -> ComboBoxProperty.(to_int Spacing)
   | `Arrow_padding -> DropdownBoxProperty.(to_int Arrow_padding)
-  | `Dropdown_items_padding ->
-      DropdownBoxProperty.(to_int Dropdown_items_padding)
+  | `Dropdown_items_spacing ->
+      DropdownBoxProperty.(to_int Dropdown_items_spacing)
   | `Text_inner_padding -> TextBoxProperty.(to_int Text_inner_padding)
-  | `Text_lines_padding -> TextBoxProperty.(to_int Text_lines_padding)
-  | `Color_selected_fg -> TextBoxProperty.(to_int Color_selected_fg)
-  | `Color_selected_bg -> TextBoxProperty.(to_int Color_selected_bg)
+  | `Text_lines_spacing -> TextBoxProperty.(to_int Text_lines_spacing)
+  | `Text_alignment_vertical -> TextBoxProperty.(to_int Text_alignment_vertical)
+  | `Text_multiline -> TextBoxProperty.(to_int Text_multiline)
+  | `Text_wrap_mode -> TextBoxProperty.(to_int Text_wrap_mode)
   | `Width_spinner -> SpinnerProperty.(to_int Width)
-  | `Padding_spinner -> SpinnerProperty.(to_int Padding)
+  | `Spacing_spinner -> SpinnerProperty.(to_int Spacing)
   | `Arrows_size -> ScrollBarProperty.(to_int Arrows_size)
   | `Arrows_visible -> ScrollBarProperty.(to_int Arrows_visible)
   | `Scroll_slider_padding -> ScrollBarProperty.(to_int Scroll_slider_padding)
@@ -149,7 +151,7 @@ let prop_to_int = function
   | `Scroll_padding -> ScrollBarProperty.(to_int Scroll_padding)
   | `Scroll_speed -> ScrollBarProperty.(to_int Scroll_speed)
   | `List_items_height -> ListViewProperty.(to_int List_items_height)
-  | `List_items_padding -> ListViewProperty.(to_int List_items_padding)
+  | `List_items_spacing -> ListViewProperty.(to_int List_items_spacing)
   | `Scrollbar_width -> ListViewProperty.(to_int Scrollbar_width)
   | `Scrollbar_side -> ListViewProperty.(to_int Scrollbar_side)
   | `Color_selector_size -> ColorPickerProperty.(to_int Color_selector_size)

--- a/src/raylib/ctypes_reexports.ml
+++ b/src/raylib/ctypes_reexports.ml
@@ -12,3 +12,4 @@ let to_voidp = Ctypes.to_voidp
 let ptr_of_int i = Ctypes.(allocate int i)
 let ptr_of_uint i = Ctypes.(allocate uint i)
 let void_ptr_of_int i = Ctypes.(to_voidp (ptr_of_int i))
+let ptr_of_string s = Ctypes.(allocate string s)

--- a/src/raylib/raylib.mli
+++ b/src/raylib/raylib.mli
@@ -14,6 +14,7 @@ val to_voidp : 'a ptr -> unit ptr
 val ptr_of_int : int -> int ptr
 val ptr_of_uint : Unsigned.uint -> Unsigned.uint ptr
 val void_ptr_of_int : int -> unit ptr
+val ptr_of_string : string -> string ptr
 
 module CArray = Ctypes.CArray
 module Raylib_c = Raylib_c


### PR DESCRIPTION
Updates raygui version from 3.0 to 3.6. This introduces some breaking changes:
- `ControlState` renamed to `State`
- `text_box_multi` was removed
- some additional parameters added for some UI controls
- some enum items were renamed

In addition, the new version makes `GuiScrollBar` internal - I've added a patch that undoes this so that applications built with 3.0 that use it can upgrade. (however, for some reason, neither this nor the other patches actually run at build on my machine, despite the `apply_patch.ml` executable working properly when I invoke it manually - this might be the subject of a separate issue)