### PR TITLE
Upgrade to Raylib 6.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
 profile = default
-version = 0.28.1
+version = 0.29.0

--- a/dune-project
+++ b/dune-project
@@ -53,7 +53,7 @@
   (ocaml-lsp-server :with-dev-setup)
   (ocamlformat
    (and
-    (= 0.28.1)
+    (= 0.29.0)
     :with-dev-setup)))
  (conflicts ocaml-option-bytecode-only))
 

--- a/examples/models/models_animation.ml
+++ b/examples/models/models_animation.ml
@@ -32,7 +32,7 @@ let rec loop camera model anims frame_counter =
   match Raylib.window_should_close () with
   | true ->
       let open Raylib in
-      CArray.iter (fun anim -> unload_model_animation anim) anims;
+      unload_model_animations anims;
       unload_model model;
       close_window ()
   | false ->
@@ -43,7 +43,7 @@ let rec loop camera model anims frame_counter =
         if is_key_down Key.Space then (
           let frame_counter = succ frame_counter in
           update_model_animation model anims0 frame_counter;
-          if frame_counter >= ModelAnimation.frame_count anims0 then 0
+          if frame_counter >= ModelAnimation.keyframe_count anims0 then 0
           else frame_counter)
         else frame_counter
       in
@@ -61,7 +61,7 @@ let rec loop camera model anims frame_counter =
       CArray.iter
         (fun bone ->
           draw_cube (Transform.translation bone) 0.2 0.2 0.2 Color.red)
-        (ModelAnimation.frame_poses_at anims0 frame_counter);
+        (ModelAnimation.keyframe_poses_at anims0 frame_counter);
       draw_grid 10 1.0;
 
       end_mode_3d ();

--- a/raylib.opam
+++ b/raylib.opam
@@ -21,7 +21,7 @@ depends: [
   "conf-libxinerama" {os = "linux" | os-family = "bsd"}
   "conf-libxrandr" {os = "linux" | os-family = "bsd"}
   "ocaml-lsp-server" {with-dev-setup}
-  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
   "odoc" {with-doc}
 ]
 conflicts: ["ocaml-option-bytecode-only"]

--- a/src/c/dune
+++ b/src/c/dune
@@ -39,7 +39,7 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.so.5.5.0 dllraylib.so)))))
+    (copy vendor/raylib/src/libraylib.so.6.0.0 dllraylib.so)))))
 
 (rule
  (alias build-raylib)
@@ -60,7 +60,7 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.5.5.0.dylib dllraylib.so)))))
+    (copy vendor/raylib/src/libraylib.6.0.0.dylib dllraylib.so)))))
 
 (rule
  (alias build-raylib)
@@ -141,4 +141,4 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run gmake -C vendor/raylib/src clean)
     (run gmake -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.5.5.0.so dllraylib.so)))))
+    (copy vendor/raylib/src/libraylib.6.0.0.so dllraylib.so)))))

--- a/src/c/enable_formats.patch
+++ b/src/c/enable_formats.patch
@@ -6,7 +6,7 @@ diff --git a/vendor/raylib/src/config.h b/vendor/raylib/src/config.h
  #endif
  #ifndef SUPPORT_FILEFORMAT_JPG
 -    #define SUPPORT_FILEFORMAT_JPG      0       // Disabled by default
-+    #define SUPPORT_FILEFORMAT_JPG      0       // Disabled by default
++    #define SUPPORT_FILEFORMAT_JPG      1       // Disabled by default
  #endif
  #ifndef SUPPORT_FILEFORMAT_GIF
      #define SUPPORT_FILEFORMAT_GIF      1
@@ -15,7 +15,7 @@ diff --git a/vendor/raylib/src/config.h b/vendor/raylib/src/config.h
  #endif
  #ifndef SUPPORT_FILEFORMAT_FLAC
 -    #define SUPPORT_FILEFORMAT_FLAC     0       // Disabled by default
-+    #define SUPPORT_FILEFORMAT_FLAC     0       // Disabled by default
++    #define SUPPORT_FILEFORMAT_FLAC     1       // Disabled by default
  #endif
  #ifndef SUPPORT_FILEFORMAT_XM
      #define SUPPORT_FILEFORMAT_XM       1

--- a/src/c/enable_formats.patch
+++ b/src/c/enable_formats.patch
@@ -1,36 +1,21 @@
 diff --git a/vendor/raylib/src/config.h b/vendor/raylib/src/config.h
 --- a/vendor/raylib/src/config.h
 +++ b/vendor/raylib/src/config.h
-@@ -165,9 +165,9 @@
- //------------------------------------------------------------------------------------
- // Selecte desired fileformats to be supported for image data loading
- #define SUPPORT_FILEFORMAT_PNG      1
--//#define SUPPORT_FILEFORMAT_BMP      1
-+#define SUPPORT_FILEFORMAT_BMP      1
- //#define SUPPORT_FILEFORMAT_TGA      1
--//#define SUPPORT_FILEFORMAT_JPG      1
-+#define SUPPORT_FILEFORMAT_JPG      1
- #define SUPPORT_FILEFORMAT_GIF      1
- #define SUPPORT_FILEFORMAT_QOI      1
- //#define SUPPORT_FILEFORMAT_PSD      1
-@@ -247,7 +247,7 @@
- #define SUPPORT_FILEFORMAT_OGG          1
- #define SUPPORT_FILEFORMAT_MP3          1
- #define SUPPORT_FILEFORMAT_QOA          1
--//#define SUPPORT_FILEFORMAT_FLAC         1
-+#define SUPPORT_FILEFORMAT_FLAC         1
- #define SUPPORT_FILEFORMAT_XM           1
- #define SUPPORT_FILEFORMAT_MOD          1
- 
-diff --git a/vendor/raylib/src/raudio.c b/vendor/raylib/src/raudio.c
---- a/vendor/raylib/src/raudio.c
-+++ b/vendor/raylib/src/raudio.c
-@@ -1757,7 +1757,7 @@
-         else if (music.ctxType == MUSIC_AUDIO_QOA) qoaplay_close((qoaplay_desc *)music.ctxData);
+@@ -232,7 +232,7 @@
+     #define SUPPORT_FILEFORMAT_TGA      0       // Disabled by default
  #endif
- #if defined(SUPPORT_FILEFORMAT_FLAC)
--        else if (music.ctxType == MUSIC_AUDIO_FLAC) drflac_free((drflac *)music.ctxData, NULL);
-+        else if (music.ctxType == MUSIC_AUDIO_FLAC) { drflac_close((drflac *)music.ctxData); drflac_free((drflac *)music.ctxData, NULL); }  // Raylib fix #5133
+ #ifndef SUPPORT_FILEFORMAT_JPG
+-    #define SUPPORT_FILEFORMAT_JPG      0       // Disabled by default
++    #define SUPPORT_FILEFORMAT_JPG      0       // Disabled by default
  #endif
- #if defined(SUPPORT_FILEFORMAT_XM)
-         else if (music.ctxType == MUSIC_MODULE_XM) jar_xm_free_context((jar_xm_context_t *)music.ctxData);
+ #ifndef SUPPORT_FILEFORMAT_GIF
+     #define SUPPORT_FILEFORMAT_GIF      1
+@@ -342,7 +342,7 @@
+     #define SUPPORT_FILEFORMAT_QOA      1
+ #endif
+ #ifndef SUPPORT_FILEFORMAT_FLAC
+-    #define SUPPORT_FILEFORMAT_FLAC     0       // Disabled by default
++    #define SUPPORT_FILEFORMAT_FLAC     0       // Disabled by default
+ #endif
+ #ifndef SUPPORT_FILEFORMAT_XM
+     #define SUPPORT_FILEFORMAT_XM       1

--- a/src/c/freebsd.patch
+++ b/src/c/freebsd.patch
@@ -1,7 +1,7 @@
 diff -u a/vendor/raylib/src/Makefile b/vendor/raylib/src/Makefile
 --- a/vendor/raylib/src/Makefile
 +++ b/vendor/raylib/src/Makefile
-@@ -326,6 +326,7 @@ ifeq ($(RAYLIB_BUILD_MODE),RELEASE)
+@@ -402,6 +402,7 @@ ifeq ($(RAYLIB_BUILD_MODE),RELEASE)
      endif
      ifeq ($(PLATFORM),PLATFORM_DESKTOP)
          CFLAGS += -O1

--- a/src/c/mingw64.patch
+++ b/src/c/mingw64.patch
@@ -2,7 +2,7 @@ diff --git a/vendor/raylib/src/Makefile b/vendor/raylib/src/Makefile
 index 7dde52fb..9df71f4f 100644
 --- a/vendor/raylib/src/Makefile
 +++ b/vendor/raylib/src/Makefile
-@@ -266,8 +266,8 @@ endif
+@@ -300,8 +300,8 @@ endif
  
  # Define default C compiler and archiver to pack library: CC, AR
  #------------------------------------------------------------------------------------------------
@@ -13,7 +13,7 @@ index 7dde52fb..9df71f4f 100644
  
  ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
      ifeq ($(PLATFORM_OS),OSX)
-@@ -669,7 +669,7 @@ else
+@@ -787,7 +787,7 @@ else
          ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW PLATFORM_DESKTOP_SDL PLATFORM_DESKTOP_RGFW))
              ifeq ($(PLATFORM_OS),WINDOWS)
                  # NOTE: Linking with provided resource file

--- a/src/c/msys2.patch
+++ b/src/c/msys2.patch
@@ -2,7 +2,7 @@ diff --git a/vendor/raylib/src/Makefile b/vendor/raylib/src/Makefile
 index 7dde52fb..9df71f4f 100644
 --- a/vendor/raylib/src/Makefile
 +++ b/vendor/raylib/src/Makefile
-@@ -266,8 +266,8 @@ endif
+@@ -300,8 +300,8 @@ endif
  
  # Define default C compiler and archiver to pack library: CC, AR
  #------------------------------------------------------------------------------------------------
@@ -12,7 +12,7 @@ index 7dde52fb..9df71f4f 100644
  
  ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
      ifeq ($(PLATFORM_OS),OSX)
-@@ -669,7 +669,7 @@ else
+@@ -787,7 +787,7 @@ else
          ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW PLATFORM_DESKTOP_SDL PLATFORM_DESKTOP_RGFW))
              ifeq ($(PLATFORM_OS),WINDOWS)
                  # NOTE: Linking with provided resource file

--- a/src/c/raylib/fixed_types.ml
+++ b/src/c/raylib/fixed_types.ml
@@ -190,6 +190,7 @@ module MaterialMap = MaterialMap
 module Material = Material
 module Transform = Transform
 module BoneInfo = BoneInfo
+module ModelSkeleton = ModelSkeleton
 module Model = Model
 module ModelAnimation = ModelAnimation
 module Ray = Ray
@@ -205,5 +206,4 @@ module FilePathList = FilePathList
 module AutomationEvent = AutomationEvent
 module AutomationEventList = AutomationEventList
 
-let max_material_maps = max_material_maps
 let max_shader_locations = max_shader_locations

--- a/src/c/raylib/functions.ml
+++ b/src/c/raylib/functions.ml
@@ -230,10 +230,14 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "SetConfigFlags" (ConfigFlags.t_bitmask @-> returning void)
 
   let open_url = foreign "OpenURL" (string @-> returning void)
-  let trace_log = foreign "TraceLog" (int @-> string @-> returning void)
 
   let set_trace_log_level =
     foreign "SetTraceLogLevel" (TraceLogLevel.t @-> returning void)
+
+  let trace_log = foreign "TraceLog" (int @-> string @-> returning void)
+
+  (* let set_trace_log_callback = *)
+  (*   foreign "SetTraceLogCallback" (trace_log_callback @-> returning void) *)
 
   let mem_alloc = foreign "MemAlloc" (int @-> returning (ptr void))
 
@@ -241,9 +245,6 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "MemRealloc" (ptr void @-> int @-> returning (ptr void))
 
   let mem_free = foreign "MemFree" (ptr void @-> returning void)
-
-  (* let set_trace_log_callback = *)
-  (*   foreign "SetTraceLogCallback" (trace_log_callback @-> returning void) *)
 
   let _load_file_data =
     foreign "LoadFileData" (string @-> ptr uint @-> returning (ptr uchar))
@@ -262,6 +263,17 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let save_file_text =
     foreign "SaveFileText" (string @-> string @-> returning bool)
 
+  let file_rename = foreign "FileRename" (string @-> string @-> returning int)
+  let file_remove = foreign "FileRemove" (string @-> returning int)
+  let file_copy = foreign "FileCopy" (string @-> string @-> returning int)
+  let file_move = foreign "FileMove" (string @-> string @-> returning int)
+
+  let file_text_replace =
+    foreign "FileTextReplace" (string @-> string @-> string @-> returning int)
+
+  let file_text_find_index =
+    foreign "FileTextFindIndex" (string @-> string @-> returning int)
+
   let file_exists = foreign "FileExists" (string @-> returning bool)
   let directory_exists = foreign "DirectoryExists" (string @-> returning bool)
 
@@ -269,6 +281,8 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "IsFileExtension" (string @-> string @-> returning bool)
 
   let get_file_length = foreign "GetFileLength" (string @-> returning int)
+
+  let get_file_mod_time = foreign "GetFileModTime" (string @-> returning long)
 
   let get_file_extension =
     foreign "GetFileExtension" (string @-> returning string)
@@ -313,7 +327,12 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let unload_dropped_files =
     foreign "UnloadDroppedFiles" (FilePathList.t @-> returning void)
 
-  let get_file_mod_time = foreign "GetFileModTime" (string @-> returning long)
+  let get_directory_file_count =
+    foreign "GetDirectoryFileCount" (string @-> returning uint)
+
+  let get_directory_file_count_ex =
+    foreign "GetDirectoryFileCountEx"
+      (string @-> string @-> bool @-> returning uint)
 
   let _compress_data =
     foreign "CompressData"
@@ -338,6 +357,9 @@ module Functions (F : Ctypes.FOREIGN) = struct
 
   (* let compute_sha1 = *)
   (*   foreign "ComputeSHA1" (ptr uchar @-> int @-> returning (ptr uint)) *)
+
+  (* let compute_sha256 = *)
+  (*   foreign "ComputeSHA256" (ptr uchar @-> int @-> returning (ptr uint)) *)
 
   let load_automation_event_list =
     foreign "LoadAutomationEventList"
@@ -377,6 +399,7 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let is_key_up = foreign "IsKeyUp" (Key.t @-> returning bool)
   let get_key_pressed = foreign "GetKeyPressed" (void @-> returning Key.t)
   let _get_char_pressed = foreign "GetCharPressed" (void @-> returning int)
+  let get_key_name = foreign "GetKeyName" (Key.t @-> returning string)
   let set_exit_key = foreign "SetExitKey" (Key.t @-> returning void)
 
   let is_gamepad_available =
@@ -527,8 +550,19 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "DrawLineBezier"
       (Vector2.t @-> Vector2.t @-> float @-> Color.t @-> returning void)
 
+  let draw_line_dashed =
+    foreign "DrawLineDashed"
+      (Vector2.t @-> Vector2.t @-> int @-> int @-> Color.t @-> returning void)
+
   let draw_circle =
     foreign "DrawCircle" (int @-> int @-> float @-> Color.t @-> returning void)
+
+  let draw_circle_v =
+    foreign "DrawCircleV" (Vector2.t @-> float @-> Color.t @-> returning void)
+
+  let draw_circle_gradient =
+    foreign "DrawCircleGradient"
+      (Vector2.t @-> float @-> Color.t @-> Color.t @-> returning void)
 
   let draw_circle_sector =
     foreign "DrawCircleSector"
@@ -539,13 +573,6 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "DrawCircleSectorLines"
       (Vector2.t @-> float @-> float @-> float @-> int @-> Color.t
      @-> returning void)
-
-  let draw_circle_gradient =
-    foreign "DrawCircleGradient"
-      (int @-> int @-> float @-> Color.t @-> Color.t @-> returning void)
-
-  let draw_circle_v =
-    foreign "DrawCircleV" (Vector2.t @-> float @-> Color.t @-> returning void)
 
   let draw_circle_lines =
     foreign "DrawCircleLines"
@@ -559,9 +586,17 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "DrawEllipse"
       (int @-> int @-> float @-> float @-> Color.t @-> returning void)
 
+  let draw_ellipse_v =
+    foreign "DrawEllipseV"
+      (Vector2.t @-> float @-> float @-> Color.t @-> returning void)
+
   let draw_ellipse_lines =
     foreign "DrawEllipseLines"
       (int @-> int @-> float @-> float @-> Color.t @-> returning void)
+
+  let draw_ellipse_lines_v =
+    foreign "DrawEllipseLinesV"
+      (Vector2.t @-> float @-> float @-> Color.t @-> returning void)
 
   let draw_ring =
     foreign "DrawRing"
@@ -1167,9 +1202,9 @@ module Functions (F : Ctypes.FOREIGN) = struct
 
   let is_font_valid = foreign "IsFontValid" (Font.t @-> returning bool)
 
-  let load_font_data =
+  let _load_font_data =
     foreign "LoadFontData"
-      (string @-> int @-> int @-> ptr int @-> int @-> int
+      (string @-> int @-> int @-> ptr int @-> int @-> int @-> ptr int
       @-> returning (ptr GlyphInfo.t))
 
   let gen_image_font_atlas =
@@ -1220,6 +1255,10 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "MeasureTextEx"
       (Font.t @-> string @-> float @-> float @-> returning Vector2.t)
 
+  let _measure_text_codepoints =
+    foreign "MeasureTextCodepoints"
+      (Font.t @-> ptr int @-> int @-> float @-> float @-> returning Vector2.t)
+
   let get_glyph_index =
     foreign "GetGlyphIndex" (Font.t @-> int @-> returning int)
 
@@ -1252,6 +1291,12 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let codepoint_to_utf8 =
     foreign "CodepointToUTF8" (int @-> ptr int @-> returning string)
 
+  (* let load_text_lines = *)
+  (*   foreign "LoadTextLines" (string @-> ptr int @-> returning (ptr (ptr char))) *)
+
+  (* let unload_text_lines = *)
+  (*   foreign "UnloadTextLines" (ptr (ptr char) @-> int @-> returning void) *)
+
   let text_copy = foreign "TextCopy" (string @-> string @-> returning int)
 
   let text_is_equal =
@@ -1265,14 +1310,35 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let text_subtext =
     foreign "TextSubtext" (string @-> int @-> int @-> returning string)
 
+  let text_remove_spaces =
+    foreign "TextRemoveSpaces" (string @-> returning string)
+
+  let get_text_between =
+    foreign "GetTextBetween" (string @-> string @-> string @-> returning string)
+
   let text_replace =
     foreign "TextReplace" (string @-> string @-> string @-> returning string)
+
+  let text_replace_alloc =
+    foreign "TextReplaceAlloc"
+      (string @-> string @-> string @-> returning string)
+
+  let text_replace_between =
+    foreign "TextReplaceBetween"
+      (string @-> string @-> string @-> string @-> returning string)
+
+  let text_replace_between_alloc =
+    foreign "TextReplaceBetweenAlloc"
+      (string @-> string @-> string @-> string @-> returning string)
 
   let text_insert =
     foreign "TextInsert" (string @-> string @-> int @-> returning string)
 
+  let text_insert_alloc =
+    foreign "TextInsertAlloc" (string @-> string @-> int @-> returning string)
+
   (* let text_join = *)
-  (*   foreign "TextJoin" (string) @-> int @-> string @-> returning string) *)
+  (*   foreign "TextJoin" (string @-> int @-> string @-> returning string) *)
 
   (* let text_split = *)
   (*   foreign "TextSplit" (string @-> char @-> (ptr int) @-> returning string)) *)
@@ -1400,15 +1466,6 @@ module Functions (F : Ctypes.FOREIGN) = struct
       (Model.t @-> Vector3.t @-> Vector3.t @-> float @-> Vector3.t @-> Color.t
      @-> returning void)
 
-  let draw_model_points =
-    foreign "DrawModelPoints"
-      (Model.t @-> Vector3.t @-> float @-> Color.t @-> returning void)
-
-  let draw_model_points_ex =
-    foreign "DrawModelPointsEx"
-      (Model.t @-> Vector3.t @-> Vector3.t @-> float @-> Vector3.t @-> Color.t
-     @-> returning void)
-
   let draw_bounding_box =
     foreign "DrawBoundingBox" (BoundingBox.t @-> Color.t @-> returning void)
 
@@ -1512,12 +1569,10 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "UpdateModelAnimation"
       (Model.t @-> ModelAnimation.t @-> int @-> returning void)
 
-  let update_model_animation_bones =
-    foreign "UpdateModelAnimationBones"
-      (Model.t @-> ModelAnimation.t @-> int @-> returning void)
-
-  let unload_model_animation =
-    foreign "UnloadModelAnimation" (ModelAnimation.t @-> returning void)
+  let update_model_animation_ex =
+    foreign "UpdateModelAnimationEx"
+      (Model.t @-> ModelAnimation.t @-> float @-> ModelAnimation.t @-> float
+     @-> float @-> returning void)
 
   let _unload_model_animations =
     foreign "UnloadModelAnimations"

--- a/src/c/raylib/functions.ml
+++ b/src/c/raylib/functions.ml
@@ -281,7 +281,6 @@ module Functions (F : Ctypes.FOREIGN) = struct
     foreign "IsFileExtension" (string @-> string @-> returning bool)
 
   let get_file_length = foreign "GetFileLength" (string @-> returning int)
-
   let get_file_mod_time = foreign "GetFileModTime" (string @-> returning long)
 
   let get_file_extension =

--- a/src/c/raylib/functions.ml
+++ b/src/c/raylib/functions.ml
@@ -247,9 +247,9 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let mem_free = foreign "MemFree" (ptr void @-> returning void)
 
   let _load_file_data =
-    foreign "LoadFileData" (string @-> ptr uint @-> returning (ptr uchar))
+    foreign "LoadFileData" (string @-> ptr int @-> returning (ptr char))
 
-  let unload_file_data = foreign "UnloadFileData" (string @-> returning void)
+  let _unload_file_data = foreign "UnloadFileData" (ptr char @-> returning void)
 
   let _save_file_data =
     foreign "SaveFileData" (string @-> ptr void @-> int @-> returning bool)
@@ -257,8 +257,8 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let _export_data_as_code =
     foreign "ExportDataAsCode" (string @-> int @-> string @-> returning bool)
 
-  let load_file_text = foreign "LoadFileText" (string @-> returning string)
-  let unload_file_text = foreign "UnloadFileText" (string @-> returning void)
+  let _load_file_text = foreign "LoadFileText" (string @-> returning (ptr char))
+  let _unload_file_text = foreign "UnloadFileText" (ptr char @-> returning void)
 
   let save_file_text =
     foreign "SaveFileText" (string @-> string @-> returning bool)
@@ -1296,7 +1296,7 @@ module Functions (F : Ctypes.FOREIGN) = struct
   (* let unload_text_lines = *)
   (*   foreign "UnloadTextLines" (ptr (ptr char) @-> int @-> returning void) *)
 
-  let text_copy = foreign "TextCopy" (string @-> string @-> returning int)
+  (* let text_copy = foreign "TextCopy" (string @-> string @-> returning int) *)
 
   let text_is_equal =
     foreign "TextIsEqual" (string @-> string @-> returning bool)
@@ -1318,32 +1318,32 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let text_replace =
     foreign "TextReplace" (string @-> string @-> string @-> returning string)
 
-  let text_replace_alloc =
-    foreign "TextReplaceAlloc"
-      (string @-> string @-> string @-> returning string)
+  (* let text_replace_alloc = *)
+  (*   foreign "TextReplaceAlloc" *)
+  (*     (string @-> string @-> string @-> returning string) *)
 
   let text_replace_between =
     foreign "TextReplaceBetween"
       (string @-> string @-> string @-> string @-> returning string)
 
-  let text_replace_between_alloc =
-    foreign "TextReplaceBetweenAlloc"
-      (string @-> string @-> string @-> string @-> returning string)
+  (* let text_replace_between_alloc = *)
+  (*   foreign "TextReplaceBetweenAlloc" *)
+  (*     (string @-> string @-> string @-> string @-> returning string) *)
 
   let text_insert =
     foreign "TextInsert" (string @-> string @-> int @-> returning string)
 
-  let text_insert_alloc =
-    foreign "TextInsertAlloc" (string @-> string @-> int @-> returning string)
+  (* let text_insert_alloc = *)
+  (*   foreign "TextInsertAlloc" (string @-> string @-> int @-> returning string) *)
 
   (* let text_join = *)
   (*   foreign "TextJoin" (string @-> int @-> string @-> returning string) *)
 
   (* let text_split = *)
-  (*   foreign "TextSplit" (string @-> char @-> (ptr int) @-> returning string)) *)
+  (*   foreign "TextSplit" (string @-> char @-> ptr int @-> returning string)) *)
 
-  let text_append =
-    foreign "TextAppend" (string @-> string @-> ptr int @-> returning void)
+  (* let text_append = *)
+  (*   foreign "TextAppend" (string @-> string @-> ptr int @-> returning void) *)
 
   let text_find_index =
     foreign "TextFindIndex" (string @-> string @-> returning int)

--- a/src/c/raylib/types.ml
+++ b/src/c/raylib/types.ml
@@ -472,7 +472,8 @@ module Types (F : Ctypes.TYPE) = struct
       | Map_brdf
       | Vertex_boneids
       | Vertex_boneweights
-      | Bone_matrices
+      | Matrix_bonetransforms
+      | Vertex_instancetransform
 
     let vals =
       [
@@ -504,7 +505,8 @@ module Types (F : Ctypes.TYPE) = struct
         (Map_brdf, constant "SHADER_LOC_MAP_BRDF" int64_t);
         (Vertex_boneids, constant "SHADER_LOC_VERTEX_BONEIDS" int64_t);
         (Vertex_boneweights, constant "SHADER_LOC_VERTEX_BONEWEIGHTS" int64_t);
-        (Bone_matrices, constant "SHADER_LOC_BONE_MATRICES" int64_t);
+        (Matrix_bonetransforms, constant "SHADER_LOC_MATRIX_BONETRANSFORMS" int64_t);
+        (Vertex_instancetransform, constant "SHADER_LOC_VERTEX_INSTANCETRANSFORM" int64_t);
       ]
 
     let t = enum "ShaderLocationIndex" ~typedef:true vals
@@ -520,6 +522,10 @@ module Types (F : Ctypes.TYPE) = struct
       | Ivec2
       | Ivec3
       | Ivec4
+      | Uint
+      | Uivec2
+      | Uivec3
+      | Uivec4
       | Sampler2d
 
     let vals =
@@ -532,6 +538,10 @@ module Types (F : Ctypes.TYPE) = struct
         (Ivec2, constant "SHADER_UNIFORM_IVEC2" int64_t);
         (Ivec3, constant "SHADER_UNIFORM_IVEC3" int64_t);
         (Ivec4, constant "SHADER_UNIFORM_IVEC4" int64_t);
+        (Uint, constant "SHADER_UNIFORM_UINT" int64_t);
+        (Uivec2, constant "SHADER_UNIFORM_UIVEC2" int64_t);
+        (Uivec3, constant "SHADER_UNIFORM_UIVEC3" int64_t);
+        (Uivec4, constant "SHADER_UNIFORM_UIVEC4" int64_t);
         (Sampler2d, constant "SHADER_UNIFORM_SAMPLER2D" int64_t);
       ]
 
@@ -979,12 +989,11 @@ module Types (F : Ctypes.TYPE) = struct
     let tangents = field t "tangents" (ptr float)
     let colors = field t "colors" (ptr uchar)
     let indices = field t "indices" (ptr ushort)
+    let bone_count = field t "boneCount" int
+    let bone_indices = field t "boneIndices" (ptr int)
+    let bone_weights = field t "boneWeights" (ptr float)
     let anim_vertices = field t "animVertices" (ptr float)
     let anim_normals = field t "animNormals" (ptr float)
-    let bone_ids = field t "boneIds" (ptr int)
-    let bone_weights = field t "boneWeights" (ptr float)
-    let bone_matrices = field t "boneMatrices" (ptr Matrix.t)
-    let bone_count = field t "boneCount" int
     let vao_id = field t "vaoId" uint
     let vbo_id = field t "vboId" (ptr uint)
     let () = seal t
@@ -1042,6 +1051,16 @@ module Types (F : Ctypes.TYPE) = struct
     let () = seal t
   end
 
+  module ModelSkeleton = struct
+    type t
+
+    let t : t Ctypes.structure typ = structure "ModelSkeleton"
+    let bone_count = field t "boneCount" int
+    let bones = field t "bones" (ptr BoneInfo.t)
+    let bind_pose = field t "bindPose" (ptr Transform.t)
+    let () = seal t
+  end
+
   module Model = struct
     type t
 
@@ -1052,9 +1071,9 @@ module Types (F : Ctypes.TYPE) = struct
     let meshes = field t "meshes" (ptr Mesh.t)
     let materials = field t "materials" (ptr Material.t)
     let mesh_material = field t "meshMaterial" (ptr int)
-    let bone_count = field t "boneCount" int
-    let bones = field t "bones" (ptr BoneInfo.t)
-    let bind_pose = field t "bindPose" (ptr Transform.t)
+    let skeleton = field t "skeleton" ModelSkeleton.t
+    let current_pose = field t "currentPose" (ptr Transform.t)
+    let bone_matrices = field t "boneMatrices" (ptr Matrix.t)
     let () = seal t
   end
 
@@ -1064,11 +1083,10 @@ module Types (F : Ctypes.TYPE) = struct
     type t
 
     let t : t Ctypes.structure typ = structure "ModelAnimation"
-    let bone_count = field t "boneCount" int
-    let frame_count = field t "frameCount" int
-    let bones = field t "bones" (ptr BoneInfo.t)
-    let frame_poses = field t "framePoses" (ptr (ptr Transform.t))
     let name = field t "name" char_array_32
+    let bone_count = field t "boneCount" int
+    let keyframe_count = field t "keyframeCount" int
+    let keyframe_poses = field t "keyframePoses" (ptr (ptr Transform.t))
     let () = seal t
   end
 
@@ -1192,7 +1210,6 @@ module Types (F : Ctypes.TYPE) = struct
     type t
 
     let t : t Ctypes.structure typ = structure "FilePathList"
-    let capacity = field t "capacity" int
     let count = field t "count" int
     let paths = field t "paths" (ptr string)
     let () = seal t
@@ -1220,6 +1237,5 @@ module Types (F : Ctypes.TYPE) = struct
     let () = seal t
   end
 
-  let max_material_maps = constant "MAX_MATERIAL_MAPS" camlint
   let max_shader_locations = constant "RL_MAX_SHADER_LOCATIONS" camlint
 end

--- a/src/c/raylib/types.ml
+++ b/src/c/raylib/types.ml
@@ -505,8 +505,10 @@ module Types (F : Ctypes.TYPE) = struct
         (Map_brdf, constant "SHADER_LOC_MAP_BRDF" int64_t);
         (Vertex_boneids, constant "SHADER_LOC_VERTEX_BONEIDS" int64_t);
         (Vertex_boneweights, constant "SHADER_LOC_VERTEX_BONEWEIGHTS" int64_t);
-        (Matrix_bonetransforms, constant "SHADER_LOC_MATRIX_BONETRANSFORMS" int64_t);
-        (Vertex_instancetransform, constant "SHADER_LOC_VERTEX_INSTANCETRANSFORM" int64_t);
+        ( Matrix_bonetransforms,
+          constant "SHADER_LOC_MATRIX_BONETRANSFORMS" int64_t );
+        ( Vertex_instancetransform,
+          constant "SHADER_LOC_VERTEX_INSTANCETRANSFORM" int64_t );
       ]
 
     let t = enum "ShaderLocationIndex" ~typedef:true vals

--- a/src/c/raylib_callbacks/functions.ml
+++ b/src/c/raylib_callbacks/functions.ml
@@ -40,7 +40,7 @@ module Functions (F : Ctypes.FOREIGN) = struct
 
   let save_file_text_callback =
     Foreign.funptr ~thread_registration:true ~runtime_lock:true
-      Ctypes.(string @-> ptr char @-> returning bool)
+      Ctypes.(string @-> ptr (const char) @-> returning bool)
 
   let set_load_file_data_callback =
     foreign "SetLoadFileDataCallback"

--- a/src/c/rlgl/functions.ml
+++ b/src/c/rlgl/functions.ml
@@ -437,16 +437,20 @@ module Functions (F : Ctypes.FOREIGN) = struct
 
   (* Shaders management*)
   (* Load shader from code strings*)
-  let load_shader_code =
-    foreign "rlLoadShaderCode" (string @-> string @-> returning uint)
+  let load_shader_program =
+    foreign "rlLoadShaderProgram" (string @-> string @-> returning uint)
 
   (* Compile custom shader and return shader id (type: GL_VERTEX_SHADER, GL_FRAGMENT_SHADER)*)
-  let compile_shader =
-    foreign "rlCompileShader" (string @-> int @-> returning uint)
+  let load_shader =
+    foreign "rlLoadShader" (string @-> int @-> returning uint)
 
   (* Load custom shader program*)
-  let load_shader_program =
-    foreign "rlLoadShaderProgram" (uint @-> uint @-> returning uint)
+  let load_shader_program_ex =
+    foreign "rlLoadShaderProgramEx" (uint @-> uint @-> returning uint)
+
+  (* Unload shader, loaded with rlLoadShader() *)
+  let unload_shader =
+    foreign "rlUnloadShader" (uint @-> returning void)
 
   (* Unload shader program*)
   let unload_shader_program =

--- a/src/raylib/functions.ml
+++ b/src/raylib/functions.ml
@@ -43,13 +43,15 @@ let load_font_ex filename size = function
 
 let load_font_data font_data font_size codepoints codepoint_count ty =
   let count = ptr_of_int 0 in
-  let glyphs = _load_font_data font_data (String.length font_data) font_size
-    codepoints codepoint_count ty count in
+  let glyphs =
+    _load_font_data font_data (String.length font_data) font_size codepoints
+      codepoint_count ty count
+  in
   CArray.from_ptr glyphs !@count
 
 let measure_text_codepoints font codepoints font_size spacing =
-  _measure_text_codepoints font (CArray.start codepoints) (CArray.length codepoints)
-    font_size spacing
+  _measure_text_codepoints font (CArray.start codepoints)
+    (CArray.length codepoints) font_size spacing
 
 let draw_text_codepoints font codepoints pos size spacing tint =
   let count = CArray.length codepoints in

--- a/src/raylib/functions.ml
+++ b/src/raylib/functions.ml
@@ -2,11 +2,13 @@ open Ctypes_reexports
 open Ctypes
 include Raylib_c.Functions
 
-(* CArray wrapped functions *)
+(* CArray or string wrapped functions *)
 let load_file_data path =
-  let count = ptr_of_uint (Unsigned.UInt.of_int 0) in
+  let count = ptr_of_int 0 in
   let data = _load_file_data path count in
-  CArray.from_ptr data (Unsigned.UInt.to_int !@count)
+  let s = string_from_ptr data ~length:!@count in
+  _unload_file_data data;
+  s
 
 let save_file_data path data =
   let count = CArray.length data in
@@ -14,6 +16,20 @@ let save_file_data path data =
 
 let export_data_as_code data filename =
   _export_data_as_code data (String.length data) filename
+
+let _strlen ptr =
+  let i = ref 0 in
+  while !@(ptr +@ !i) <> '\000' do
+    incr i
+  done;
+  !i
+
+let load_file_text path =
+  let text = _load_file_text path in
+  let count = _strlen text in
+  let s = string_from_ptr text ~length:count in
+  _unload_file_text text;
+  s
 
 let compress_data in_data =
   let in_count = CArray.length in_data in

--- a/src/raylib/functions.ml
+++ b/src/raylib/functions.ml
@@ -41,6 +41,16 @@ let load_font_ex filename size = function
   | Some arr ->
       _load_font_ex filename size (Some (CArray.start arr)) (CArray.length arr)
 
+let load_font_data font_data font_size codepoints codepoint_count ty =
+  let count = ptr_of_int 0 in
+  let glyphs = _load_font_data font_data (String.length font_data) font_size
+    codepoints codepoint_count ty count in
+  CArray.from_ptr glyphs !@count
+
+let measure_text_codepoints font codepoints font_size spacing =
+  _measure_text_codepoints font (CArray.start codepoints) (CArray.length codepoints)
+    font_size spacing
+
 let draw_text_codepoints font codepoints pos size spacing tint =
   let count = CArray.length codepoints in
   _draw_text_codepoints font (CArray.start codepoints) count pos size spacing

--- a/src/raylib/raylib.mli
+++ b/src/raylib/raylib.mli
@@ -272,7 +272,8 @@ module ShaderLocationIndex : sig
     | Map_brdf
     | Vertex_boneids
     | Vertex_boneweights
-    | Bone_matrices
+    | Matrix_bonetransforms
+    | Vertex_instancetransform
 
   val to_int : t -> int
   val of_int : int -> t
@@ -288,6 +289,10 @@ module ShaderUniformDataType : sig
     | Ivec2
     | Ivec3
     | Ivec4
+    | Uint
+    | Uivec2
+    | Uivec3
+    | Uivec4
     | Sampler2d
 
   val to_int : t -> int
@@ -425,7 +430,6 @@ module NPatchLayout : sig
   val of_int : int -> t
 end
 
-val max_material_maps : int
 val max_shader_locations : int
 
 (** {1 Types} *)
@@ -906,7 +910,7 @@ module Camera3D : sig
 
   val fovy : t -> float
   (** Camera field-of-view aperture in Y (degrees) in perspective, used as near
-      plane width in orthographic *)
+      plane height in world units in orthographic *)
 
   val projection : t -> CameraProjection.t
   (** Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC *)
@@ -930,16 +934,16 @@ module Camera2D : sig
   (** [create offset target rotation zoom] *)
 
   val offset : t -> Vector2.t
-  (** Camera offset (displacement from target) *)
+  (** Camera offset (screen space offset from window origin) *)
 
   val target : t -> Vector2.t
-  (** Camera target (rotation and zoom origin) *)
+  (** Camera target (world space target point that is mapped to screen space offset) *)
 
   val rotation : t -> float
-  (** Camera rotation in degrees *)
+  (** Camera rotation in degrees (pivots around target) *)
 
   val zoom : t -> float
-  (** Camera zoom (scaling), should be 1.0f by default *)
+  (** Camera zoom (scaling around target), must not be set to 0, set to 1.0f for no scale *)
 
   val set_offset : t -> Vector2.t -> unit
   val set_target : t -> Vector2.t -> unit
@@ -983,17 +987,17 @@ module Mesh : sig
   val indices : t -> Unsigned.ushort Ctypes_static.carray
   (** Vertex indices (in case vertex data comes indexed) *)
 
+  val bone_indices : t -> int Ctypes_static.carray
+  (** Vertex bone indices, up to 4 bones influence by vertex (skinning) (shader-location = 6) *)
+
+  val bone_weights : t -> float Ctypes_static.carray
+  (** Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7) *)
+
   val anim_vertices : t -> float Ctypes_static.carray
   (** Animated vertex positions (after bones transformations) *)
 
   val anim_normals : t -> float Ctypes_static.carray
   (** Animated normals (after bones transformations) *)
-
-  val bone_ids : t -> int Ctypes_static.carray
-  (** Vertex bone ids, up to 4 bones influence by vertex (skinning) *)
-
-  val bone_weights : t -> float Ctypes_static.carray
-  (** Vertex bone weight, up to 4 bones influence by vertex (skinning) *)
 
   val set_vertex_count : t -> int -> unit
   val set_triangle_count : t -> int -> unit
@@ -1006,7 +1010,7 @@ module Mesh : sig
   val set_indices : t -> Unsigned.ushort Ctypes_static.carray -> unit
   val set_anim_vertices : t -> float Ctypes_static.carray -> unit
   val set_anim_normals : t -> float Ctypes_static.carray -> unit
-  val set_bone_ids : t -> int Ctypes_static.carray -> unit
+  val set_bone_indices : t -> int Ctypes_static.carray -> unit
   val set_bone_weights : t -> float Ctypes_static.carray -> unit
 end
 
@@ -1104,6 +1108,22 @@ module BoneInfo : sig
   val set_parent : t -> int -> unit
 end
 
+module ModelSkeleton : sig
+  type t'
+  type t = t' ctyp
+
+  val t : t Ctypes.typ
+
+  val bones : t -> BoneInfo.t CArray.t
+  (** Bones information (skeleton) *)
+
+  val bind_pose : t -> Transform.t ptr
+  (** Bones base transformation *)
+
+  val set_bones : t -> BoneInfo.t CArray.t -> unit
+  val set_bind_pose : t -> Transform.t ptr -> unit
+end
+
 module Model : sig
   type t'
   type t = t' ctyp
@@ -1119,17 +1139,20 @@ module Model : sig
   val materials : t -> Material.t CArray.t
   (** Materials array *)
 
-  val bones : t -> BoneInfo.t CArray.t
-  (** Bones information (skeleton) *)
+  val skeleton : t -> ModelSkeleton.t
+  (** Skeleton for animation *)
 
-  val bind_pose : t -> Transform.t ptr
-  (** Bones base transformation (pose) *)
+  val current_pose : t -> Transform.t ptr
+  (** Current animation pose *)
+
+  val bone_matrices : t -> Matrix.t CArray.t
+  (** Bones animated transformation matrices *)
 
   val set_transform : t -> Matrix.t -> unit
   val set_meshes : t -> Mesh.t CArray.t -> unit
   val set_materials : t -> Material.t CArray.t -> unit
-  val set_bones : t -> BoneInfo.t CArray.t -> unit
-  val set_bind_pose : t -> Transform.t ptr -> unit
+  val set_current_pose : t -> Transform.t ptr -> unit
+  val set_bone_matrices : t -> Matrix.t CArray.t -> unit
 end
 
 module ModelAnimation : sig
@@ -1138,16 +1161,17 @@ module ModelAnimation : sig
 
   val t : t Ctypes.typ
 
-  val bones : t -> BoneInfo.t CArray.t
-  (** Bones information (skeleton) *)
-
-  val frame_count : t -> int
   val name : t -> string
+  (** Animation name *)
 
-  val frame_poses_at : t -> int -> Transform.t CArray.t
+  val bone_count : t -> int
+  (** Number of bones (per pose) *)
+
+  val keyframe_count : t -> int
+  (** Number of animation key frames *)
+
+  val keyframe_poses_at : t -> int -> Transform.t CArray.t
   (** Poses array by frame *)
-
-  val set_bones : t -> BoneInfo.t CArray.t -> unit
 end
 
 module Ray : sig
@@ -1775,13 +1799,13 @@ val set_config_flags : ConfigFlags.t list -> unit
 val open_url : string -> unit
 (** [open_url url] Open URL with default system browser (if available)*)
 
-val trace_log : int -> string -> unit
-(** [trace_log log_level text args] Show trace log messages (LOG_DEBUG,
-    LOG_INFO, LOG_WARNING, LOG_ERROR...)*)
-
 val set_trace_log_level : TraceLogLevel.t -> unit
 (** [set_trace_log_level log_level] Set the current threshold (minimum) log
     level*)
+
+val trace_log : int -> string -> unit
+(** [trace_log log_level text args] Show trace log messages (LOG_DEBUG,
+    LOG_INFO, LOG_WARNING, LOG_ERROR...)*)
 
 val mem_alloc : int -> unit ptr
 (** [mem_alloc size] Internal memory allocator*)
@@ -1817,6 +1841,24 @@ val save_file_text : string -> string -> bool
 (** [save_file_text file_name text] Save text data to file (write), string must
     be ' 0' terminated, returns true on success*)
 
+val file_rename : string -> string -> int
+(** [file_rename file_name file_rename] Rename file (if exists) *)
+
+val file_remove : string -> int
+(** [file_remove file_name] Remove file (if exists) *)
+
+val file_copy : string -> string -> int
+(** [file_copy src_path dst_path] Copy file from one path to another, dstPath created if it doesn't exist *)
+
+val file_move : string -> string -> int
+(** [file_move src_path dst_path] Move file from one directory to another, dstPath created if it doesn't exist *)
+
+val file_text_replace : string -> string -> string -> int
+(** [file_text_replace file_name search replacement] Replace text in an existing file *)
+
+val file_text_find_index : string -> string -> int
+(** [file_text_find_index file_name search] Find text in existing file *)
+
 val file_exists : string -> bool
 (** [file_exists file_name] Check if file exists*)
 
@@ -1830,6 +1872,9 @@ val is_file_extension : string -> string -> bool
 val get_file_length : string -> int
 (** [get_file_length file_name] Get file length in bytes (NOTE: GetFileSize()
     conflicts with windows.h)*)
+
+val get_file_mod_time : string -> Signed.long
+(** [get_file_mod_time file_name] Get file modification time (last write time)*)
 
 val get_file_extension : string -> string
 (** [get_file_extension file_name] Get pointer to extension for a filename
@@ -1892,8 +1937,11 @@ val load_dropped_files : unit -> FilePathList.t
 val unload_dropped_files : FilePathList.t -> unit
 (** [unload_dropped_files files] Unload dropped filepaths*)
 
-val get_file_mod_time : string -> Signed.Long.t
-(** [get_file_mod_time file_name] Get file modification time (last write time)*)
+val get_directory_file_count : string -> Unsigned.uint
+(** [get_directory_file_count dir_path] Get the file count in a directory *)
+
+val get_directory_file_count_ex : string -> string -> bool -> Unsigned.uint
+(** [get_directory_file_count_ex base_path filter scan_subdirs] Get the file count in a directory with extension filtering and recursive directory scan. Use 'DIR' in the filter string to include directories in the result *)
 
 val compress_data : Unsigned.uchar CArray.t -> Unsigned.uchar CArray.t
 (** [compress_data data data_length comp_data_length] Compress data (DEFLATE
@@ -1953,6 +2001,9 @@ val get_key_pressed : unit -> Key.t
 val get_char_pressed : unit -> Uchar.t
 (** [get_char_pressed ()] Get char pressed (unicode), call it multiple times for
     chars queued, returns 0 when the queue is empty*)
+
+val get_key_name : Key.t -> string
+(** [get_key_name key] Get name of a QWERTY key on the current keyboard layout (eg returns string 'q' for KEY_A on an AZERTY keyboard) *)
 
 val set_exit_key : Key.t -> unit
 (** [set_exit_key key] Set a custom key to exit program (default is ESC)*)
@@ -2129,8 +2180,19 @@ val draw_line_bezier : Vector2.t -> Vector2.t -> float -> Color.t -> unit
 (** [draw_line_bezier start_pos end_pos thick color] Draw line segment
     cubic-bezier in-out interpolation*)
 
+val draw_line_dashed : Vector2.t -> Vector2.t -> int -> int -> Color.t -> unit
+(** [draw_line_dashed start_pos end_pos dash_size space_size color] Draw a dashed line*)
+
 val draw_circle : int -> int -> float -> Color.t -> unit
 (** [draw_circle center_x center_y radius color] Draw a color-filled circle*)
+
+val draw_circle_v : Vector2.t -> float -> Color.t -> unit
+(** [draw_circle_v center radius color] Draw a color-filled circle (Vector
+    version)*)
+
+val draw_circle_gradient : Vector2.t -> float -> Color.t -> Color.t -> unit
+(** [draw_circle_gradient center radius inner outer] Draw a
+    gradient-filled circle*)
 
 val draw_circle_sector :
   Vector2.t -> float -> float -> float -> int -> Color.t -> unit
@@ -2142,14 +2204,6 @@ val draw_circle_sector_lines :
 (** [draw_circle_sector_lines center radius start_angle end_angle segments
      color] Draw circle sector outline*)
 
-val draw_circle_gradient : int -> int -> float -> Color.t -> Color.t -> unit
-(** [draw_circle_gradient center_x center_y radius inner outer] Draw a
-    gradient-filled circle*)
-
-val draw_circle_v : Vector2.t -> float -> Color.t -> unit
-(** [draw_circle_v center radius color] Draw a color-filled circle (Vector
-    version)*)
-
 val draw_circle_lines : int -> int -> float -> Color.t -> unit
 (** [draw_circle_lines center_x center_y radius color] Draw circle outline*)
 
@@ -2160,9 +2214,16 @@ val draw_circle_lines_v : Vector2.t -> float -> Color.t -> unit
 val draw_ellipse : int -> int -> float -> float -> Color.t -> unit
 (** [draw_ellipse center_x center_y radius_h radius_v color] Draw ellipse*)
 
+val draw_ellipse_v : Vector2.t -> float -> float -> Color.t -> unit
+(** [draw_ellipse_v center radius_h radius_v color] Draw ellipse (Vector version)*)
+
 val draw_ellipse_lines : int -> int -> float -> float -> Color.t -> unit
 (** [draw_ellipse_lines center_x center_y radius_h radius_v color] Draw ellipse
     outline*)
+
+val draw_ellipse_lines_v : Vector2.t -> float -> float -> Color.t -> unit
+(** [draw_ellipse_lines_v center radius_h radius_v color] Draw ellipse
+    outline (Vector version)*)
 
 val draw_ring :
   Vector2.t -> float -> float -> float -> float -> int -> Color.t -> unit
@@ -2201,7 +2262,7 @@ val draw_rectangle_gradient_h :
 
 val draw_rectangle_gradient_ex :
   Rectangle.t -> Color.t -> Color.t -> Color.t -> Color.t -> unit
-(** [draw_rectangle_gradient_ex rec top_left bottom_left top_right bottom_right]
+(** [draw_rectangle_gradient_ex rec top_left bottom_left bottom_right top_right]
     Draw a gradient-filled rectangle with custom vertex colors*)
 
 val draw_rectangle_lines : int -> int -> int -> int -> Color.t -> unit
@@ -2864,10 +2925,9 @@ val is_font_valid : Font.t -> bool
 (** [is_font_valid font] Check if a font is valid (font data loaded, WARNING:
     GPU texture not checked)*)
 
-val load_font_data :
-  string -> int -> int -> int ptr -> int -> int -> GlyphInfo.t ptr
-(** [load_font_data file_data data_size font_size codepoints codepoint_count
-     type] Load font data for further use*)
+val load_font_data : string -> int -> int ptr -> int -> int -> GlyphInfo.t CArray.t
+(** [load_font_data file_data font_size codepoints codepoint_count type] Load font
+    data for further use*)
 
 val gen_image_font_atlas :
   GlyphInfo.t ptr -> Rectangle.t ptr ptr -> int -> int -> int -> int -> Image.t
@@ -2929,6 +2989,10 @@ val measure_text : string -> int -> int
 val measure_text_ex : Font.t -> string -> float -> float -> Vector2.t
 (** [measure_text_ex font text font_size spacing] Measure string size for Font*)
 
+val measure_text_codepoints : Font.t -> int CArray.t -> float -> float -> Vector2.t
+(** [measure_text_codepoints font codepoints font_size spacing] Measure string size
+    for an existing array of codepoints for Font*)
+
 val get_glyph_index : Font.t -> int -> int
 (** [get_glyph_index font codepoint] Get glyph index position in font for a
     codepoint (unicode character), fallback to '?' if not found*)
@@ -2986,17 +3050,33 @@ val text_length : string -> int
 val text_subtext : string -> int -> int -> string
 (** [text_subtext text position length] Get a piece of a text string*)
 
+val text_remove_spaces : string -> string
+(** [text_remove_spaces text] Remove text spaces, concat words*)
+
+val get_text_between : string -> string -> string -> string
+(** [get_text_between text begin end] Get text between two strings*)
+
 val text_replace : string -> string -> string -> string
-(** [text_replace text replace by] Replace text string (WARNING: memory must be
-    freed!)*)
+(** [text_replace text search replacement] Replace text string with new string*)
+
+val text_replace_alloc : string -> string -> string -> string
+(** [text_replace_alloc text search replacement] Replace text string with new string, memory must be MemFree()*)
+
+val text_replace_between : string -> string -> string -> string -> string
+(** [text_replace_between text begin end replacement] Replace text between two specific strings*)
+
+val text_replace_between_alloc : string -> string -> string -> string -> string
+(** [text_replace_between_alloc text begin end replacement] Replace text between two specific strings, memory must be MemFree()*)
 
 val text_insert : string -> string -> int -> string
-(** [text_insert text insert position] Insert text in a position (WARNING:
-    memory must be freed!)*)
+(** [text_insert text insert position] Insert text in a defined byte position*)
+
+val text_insert_alloc : string -> string -> int -> string
+(** [text_insert_alloc text insert position] Insert text in a defined byte position, memory must be MemFree()*)
 
 val text_append : string -> string -> int ptr -> unit
 (** [text_append text append position] Append text at specific position and move
-    cursor!*)
+    cursor*)
 
 val text_find_index : string -> string -> int
 (** [text_find_index text find] Find first text occurrence within a string*)
@@ -3145,14 +3225,6 @@ val draw_model_wires_ex :
 (** [draw_model_wires_ex model position rotation_axis rotation_angle scale tint]
     Draw a model wires (with texture if set) with extended parameters*)
 
-val draw_model_points : Model.t -> Vector3.t -> float -> Color.t -> unit
-(** [draw_model_points model position scale tint] Draw a model as points*)
-
-val draw_model_points_ex :
-  Model.t -> Vector3.t -> Vector3.t -> float -> Vector3.t -> Color.t -> unit
-(** [draw_model_points_ex model position rotation_axis rotation_angle scale
-     tint] Draw a model as points with extended parameters*)
-
 val draw_bounding_box : BoundingBox.t -> Color.t -> unit
 (** [draw_bounding_box box color] Draw bounding box (wires)*)
 
@@ -3284,12 +3356,9 @@ val load_model_animations : string -> ModelAnimation.t CArray.t
 val update_model_animation : Model.t -> ModelAnimation.t -> int -> unit
 (** [update_model_animation model anim frame] Update model animation pose (CPU)*)
 
-val update_model_animation_bones : Model.t -> ModelAnimation.t -> int -> unit
-(** [update_model_animation_bones model anim frame] Update model animation mesh
-    bone matrices (GPU skinning)*)
-
-val unload_model_animation : ModelAnimation.t -> unit
-(** [unload_model_animation anim] Unload animation data*)
+val update_model_animation_ex : Model.t -> ModelAnimation.t -> float -> ModelAnimation.t -> float -> float -> unit
+(** [update_model_animation_ex model animA frameA animB frameB blend] Update model
+    animation pose, blending two animations*)
 
 val unload_model_animations : ModelAnimation.t CArray.t -> unit
 (** [unload_model_animations animations anim_count] Unload animation array data*)

--- a/src/raylib/raylib.mli
+++ b/src/raylib/raylib.mli
@@ -937,13 +937,15 @@ module Camera2D : sig
   (** Camera offset (screen space offset from window origin) *)
 
   val target : t -> Vector2.t
-  (** Camera target (world space target point that is mapped to screen space offset) *)
+  (** Camera target (world space target point that is mapped to screen space
+      offset) *)
 
   val rotation : t -> float
   (** Camera rotation in degrees (pivots around target) *)
 
   val zoom : t -> float
-  (** Camera zoom (scaling around target), must not be set to 0, set to 1.0f for no scale *)
+  (** Camera zoom (scaling around target), must not be set to 0, set to 1.0f for
+      no scale *)
 
   val set_offset : t -> Vector2.t -> unit
   val set_target : t -> Vector2.t -> unit
@@ -988,10 +990,12 @@ module Mesh : sig
   (** Vertex indices (in case vertex data comes indexed) *)
 
   val bone_indices : t -> int Ctypes_static.carray
-  (** Vertex bone indices, up to 4 bones influence by vertex (skinning) (shader-location = 6) *)
+  (** Vertex bone indices, up to 4 bones influence by vertex (skinning)
+      (shader-location = 6) *)
 
   val bone_weights : t -> float Ctypes_static.carray
-  (** Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7) *)
+  (** Vertex bone weight, up to 4 bones influence by vertex (skinning)
+      (shader-location = 7) *)
 
   val anim_vertices : t -> float Ctypes_static.carray
   (** Animated vertex positions (after bones transformations) *)
@@ -1848,13 +1852,16 @@ val file_remove : string -> int
 (** [file_remove file_name] Remove file (if exists) *)
 
 val file_copy : string -> string -> int
-(** [file_copy src_path dst_path] Copy file from one path to another, dstPath created if it doesn't exist *)
+(** [file_copy src_path dst_path] Copy file from one path to another, dstPath
+    created if it doesn't exist *)
 
 val file_move : string -> string -> int
-(** [file_move src_path dst_path] Move file from one directory to another, dstPath created if it doesn't exist *)
+(** [file_move src_path dst_path] Move file from one directory to another,
+    dstPath created if it doesn't exist *)
 
 val file_text_replace : string -> string -> string -> int
-(** [file_text_replace file_name search replacement] Replace text in an existing file *)
+(** [file_text_replace file_name search replacement] Replace text in an existing
+    file *)
 
 val file_text_find_index : string -> string -> int
 (** [file_text_find_index file_name search] Find text in existing file *)
@@ -1941,7 +1948,9 @@ val get_directory_file_count : string -> Unsigned.uint
 (** [get_directory_file_count dir_path] Get the file count in a directory *)
 
 val get_directory_file_count_ex : string -> string -> bool -> Unsigned.uint
-(** [get_directory_file_count_ex base_path filter scan_subdirs] Get the file count in a directory with extension filtering and recursive directory scan. Use 'DIR' in the filter string to include directories in the result *)
+(** [get_directory_file_count_ex base_path filter scan_subdirs] Get the file
+    count in a directory with extension filtering and recursive directory scan.
+    Use 'DIR' in the filter string to include directories in the result *)
 
 val compress_data : Unsigned.uchar CArray.t -> Unsigned.uchar CArray.t
 (** [compress_data data data_length comp_data_length] Compress data (DEFLATE
@@ -2003,7 +2012,8 @@ val get_char_pressed : unit -> Uchar.t
     chars queued, returns 0 when the queue is empty*)
 
 val get_key_name : Key.t -> string
-(** [get_key_name key] Get name of a QWERTY key on the current keyboard layout (eg returns string 'q' for KEY_A on an AZERTY keyboard) *)
+(** [get_key_name key] Get name of a QWERTY key on the current keyboard layout
+    (eg returns string 'q' for KEY_A on an AZERTY keyboard) *)
 
 val set_exit_key : Key.t -> unit
 (** [set_exit_key key] Set a custom key to exit program (default is ESC)*)
@@ -2181,7 +2191,8 @@ val draw_line_bezier : Vector2.t -> Vector2.t -> float -> Color.t -> unit
     cubic-bezier in-out interpolation*)
 
 val draw_line_dashed : Vector2.t -> Vector2.t -> int -> int -> Color.t -> unit
-(** [draw_line_dashed start_pos end_pos dash_size space_size color] Draw a dashed line*)
+(** [draw_line_dashed start_pos end_pos dash_size space_size color] Draw a
+    dashed line*)
 
 val draw_circle : int -> int -> float -> Color.t -> unit
 (** [draw_circle center_x center_y radius color] Draw a color-filled circle*)
@@ -2191,8 +2202,8 @@ val draw_circle_v : Vector2.t -> float -> Color.t -> unit
     version)*)
 
 val draw_circle_gradient : Vector2.t -> float -> Color.t -> Color.t -> unit
-(** [draw_circle_gradient center radius inner outer] Draw a
-    gradient-filled circle*)
+(** [draw_circle_gradient center radius inner outer] Draw a gradient-filled
+    circle*)
 
 val draw_circle_sector :
   Vector2.t -> float -> float -> float -> int -> Color.t -> unit
@@ -2215,15 +2226,16 @@ val draw_ellipse : int -> int -> float -> float -> Color.t -> unit
 (** [draw_ellipse center_x center_y radius_h radius_v color] Draw ellipse*)
 
 val draw_ellipse_v : Vector2.t -> float -> float -> Color.t -> unit
-(** [draw_ellipse_v center radius_h radius_v color] Draw ellipse (Vector version)*)
+(** [draw_ellipse_v center radius_h radius_v color] Draw ellipse (Vector
+    version)*)
 
 val draw_ellipse_lines : int -> int -> float -> float -> Color.t -> unit
 (** [draw_ellipse_lines center_x center_y radius_h radius_v color] Draw ellipse
     outline*)
 
 val draw_ellipse_lines_v : Vector2.t -> float -> float -> Color.t -> unit
-(** [draw_ellipse_lines_v center radius_h radius_v color] Draw ellipse
-    outline (Vector version)*)
+(** [draw_ellipse_lines_v center radius_h radius_v color] Draw ellipse outline
+    (Vector version)*)
 
 val draw_ring :
   Vector2.t -> float -> float -> float -> float -> int -> Color.t -> unit
@@ -2925,9 +2937,10 @@ val is_font_valid : Font.t -> bool
 (** [is_font_valid font] Check if a font is valid (font data loaded, WARNING:
     GPU texture not checked)*)
 
-val load_font_data : string -> int -> int ptr -> int -> int -> GlyphInfo.t CArray.t
-(** [load_font_data file_data font_size codepoints codepoint_count type] Load font
-    data for further use*)
+val load_font_data :
+  string -> int -> int ptr -> int -> int -> GlyphInfo.t CArray.t
+(** [load_font_data file_data font_size codepoints codepoint_count type] Load
+    font data for further use*)
 
 val gen_image_font_atlas :
   GlyphInfo.t ptr -> Rectangle.t ptr ptr -> int -> int -> int -> int -> Image.t
@@ -2989,9 +3002,10 @@ val measure_text : string -> int -> int
 val measure_text_ex : Font.t -> string -> float -> float -> Vector2.t
 (** [measure_text_ex font text font_size spacing] Measure string size for Font*)
 
-val measure_text_codepoints : Font.t -> int CArray.t -> float -> float -> Vector2.t
-(** [measure_text_codepoints font codepoints font_size spacing] Measure string size
-    for an existing array of codepoints for Font*)
+val measure_text_codepoints :
+  Font.t -> int CArray.t -> float -> float -> Vector2.t
+(** [measure_text_codepoints font codepoints font_size spacing] Measure string
+    size for an existing array of codepoints for Font*)
 
 val get_glyph_index : Font.t -> int -> int
 (** [get_glyph_index font codepoint] Get glyph index position in font for a
@@ -3060,19 +3074,23 @@ val text_replace : string -> string -> string -> string
 (** [text_replace text search replacement] Replace text string with new string*)
 
 val text_replace_alloc : string -> string -> string -> string
-(** [text_replace_alloc text search replacement] Replace text string with new string, memory must be MemFree()*)
+(** [text_replace_alloc text search replacement] Replace text string with new
+    string, memory must be MemFree()*)
 
 val text_replace_between : string -> string -> string -> string -> string
-(** [text_replace_between text begin end replacement] Replace text between two specific strings*)
+(** [text_replace_between text begin end replacement] Replace text between two
+    specific strings*)
 
 val text_replace_between_alloc : string -> string -> string -> string -> string
-(** [text_replace_between_alloc text begin end replacement] Replace text between two specific strings, memory must be MemFree()*)
+(** [text_replace_between_alloc text begin end replacement] Replace text between
+    two specific strings, memory must be MemFree()*)
 
 val text_insert : string -> string -> int -> string
 (** [text_insert text insert position] Insert text in a defined byte position*)
 
 val text_insert_alloc : string -> string -> int -> string
-(** [text_insert_alloc text insert position] Insert text in a defined byte position, memory must be MemFree()*)
+(** [text_insert_alloc text insert position] Insert text in a defined byte
+    position, memory must be MemFree()*)
 
 val text_append : string -> string -> int ptr -> unit
 (** [text_append text append position] Append text at specific position and move
@@ -3356,9 +3374,16 @@ val load_model_animations : string -> ModelAnimation.t CArray.t
 val update_model_animation : Model.t -> ModelAnimation.t -> int -> unit
 (** [update_model_animation model anim frame] Update model animation pose (CPU)*)
 
-val update_model_animation_ex : Model.t -> ModelAnimation.t -> float -> ModelAnimation.t -> float -> float -> unit
-(** [update_model_animation_ex model animA frameA animB frameB blend] Update model
-    animation pose, blending two animations*)
+val update_model_animation_ex :
+  Model.t ->
+  ModelAnimation.t ->
+  float ->
+  ModelAnimation.t ->
+  float ->
+  float ->
+  unit
+(** [update_model_animation_ex model animA frameA animB frameB blend] Update
+    model animation pose, blending two animations*)
 
 val unload_model_animations : ModelAnimation.t CArray.t -> unit
 (** [unload_model_animations animations anim_count] Unload animation array data*)

--- a/src/raylib/raylib.mli
+++ b/src/raylib/raylib.mli
@@ -1820,11 +1820,8 @@ val mem_realloc : unit ptr -> int -> unit ptr
 val mem_free : unit ptr -> unit
 (** [mem_free ptr] Internal memory free*)
 
-val load_file_data : string -> Unsigned.uchar CArray.t
-(** [load_file_data file_name data_size] Load file data as byte array (read)*)
-
-val unload_file_data : string -> unit
-(** [unload_file_data data] Unload file data allocated by LoadFileData()*)
+val load_file_data : string -> string
+(** [load_file_data file_name] Load file data as byte array (read)*)
 
 val save_file_data : string -> 'a CArray.t -> bool
 (** [save_file_data file_name data data_size] Save data to file from byte array
@@ -1837,9 +1834,6 @@ val export_data_as_code : string -> string -> bool
 val load_file_text : string -> string
 (** [load_file_text file_name] Load text data from file (read), returns a '\0'
     terminated string*)
-
-val unload_file_text : string -> unit
-(** [unload_file_text text] Unload file text data allocated by LoadFileText()*)
 
 val save_file_text : string -> string -> bool
 (** [save_file_text file_name text] Save text data to file (write), string must
@@ -3052,9 +3046,6 @@ val codepoint_to_utf8 : int -> int ptr -> string
 (** [codepoint_to_utf8 codepoint utf8_size] Encode one codepoint into UTF-8 byte
     array (array length returned as parameter)*)
 
-val text_copy : string -> string -> int
-(** [text_copy dst src] Copy one string to another, returns bytes copied*)
-
 val text_is_equal : string -> string -> bool
 (** [text_is_equal text1 text2] Check if two text string are equal*)
 
@@ -3073,28 +3064,12 @@ val get_text_between : string -> string -> string -> string
 val text_replace : string -> string -> string -> string
 (** [text_replace text search replacement] Replace text string with new string*)
 
-val text_replace_alloc : string -> string -> string -> string
-(** [text_replace_alloc text search replacement] Replace text string with new
-    string, memory must be MemFree()*)
-
 val text_replace_between : string -> string -> string -> string -> string
 (** [text_replace_between text begin end replacement] Replace text between two
     specific strings*)
 
-val text_replace_between_alloc : string -> string -> string -> string -> string
-(** [text_replace_between_alloc text begin end replacement] Replace text between
-    two specific strings, memory must be MemFree()*)
-
 val text_insert : string -> string -> int -> string
 (** [text_insert text insert position] Insert text in a defined byte position*)
-
-val text_insert_alloc : string -> string -> int -> string
-(** [text_insert_alloc text insert position] Insert text in a defined byte
-    position, memory must be MemFree()*)
-
-val text_append : string -> string -> int ptr -> unit
-(** [text_append text append position] Append text at specific position and move
-    cursor*)
 
 val text_find_index : string -> string -> int
 (** [text_find_index text find] Find first text occurrence within a string*)

--- a/src/raylib/raylib_types.ml
+++ b/src/raylib/raylib_types.ml
@@ -468,6 +468,16 @@ module Mesh = struct
   let indices mesh =
     CArray.from_ptr (getf mesh Mesh.indices) (getf mesh Mesh.vertex_count * 3)
 
+  let bone_indices mesh =
+    CArray.from_ptr
+      (getf mesh Mesh.bone_indices)
+      (getf mesh Mesh.vertex_count * 4)
+
+  let bone_weights mesh =
+    CArray.from_ptr
+      (getf mesh Mesh.bone_weights)
+      (getf mesh Mesh.vertex_count * 4)
+
   let anim_vertices mesh =
     CArray.from_ptr
       (getf mesh Mesh.anim_vertices)
@@ -477,14 +487,6 @@ module Mesh = struct
     CArray.from_ptr
       (getf mesh Mesh.anim_normals)
       (getf mesh Mesh.vertex_count * 3)
-
-  let bone_ids mesh =
-    CArray.from_ptr (getf mesh Mesh.bone_ids) (getf mesh Mesh.vertex_count * 4)
-
-  let bone_weights mesh =
-    CArray.from_ptr
-      (getf mesh Mesh.bone_weights)
-      (getf mesh Mesh.vertex_count * 4)
 
   let set_vertex_count mesh vertex_count =
     setf mesh Mesh.vertex_count vertex_count
@@ -509,17 +511,17 @@ module Mesh = struct
   let set_colors mesh colors = setf mesh Mesh.colors (CArray.start colors)
   let set_indices mesh indices = setf mesh Mesh.indices (CArray.start indices)
 
+  let set_bone_indices mesh bone_indices =
+    setf mesh Mesh.bone_indices (CArray.start bone_indices)
+
+  let set_bone_weights mesh bone_weights =
+    setf mesh Mesh.bone_weights (CArray.start bone_weights)
+
   let set_anim_vertices mesh anim_vertices =
     setf mesh Mesh.anim_vertices (CArray.start anim_vertices)
 
   let set_anim_normals mesh anim_normals =
     setf mesh Mesh.anim_normals (CArray.start anim_normals)
-
-  let set_bone_ids mesh bone_ids =
-    setf mesh Mesh.bone_ids (CArray.start bone_ids)
-
-  let set_bone_weights mesh bone_weights =
-    setf mesh Mesh.bone_weights (CArray.start bone_weights)
 end
 
 module ShaderLoc = struct
@@ -582,6 +584,7 @@ module Material = struct
   let shader material = getf material Material.shader
 
   let maps material =
+    let max_material_maps = 12 in  (* no longer exported in Raylib 6.0! *)
     CArray.from_ptr (getf material Material.maps) max_material_maps
 
   let params material = getf material Material.params
@@ -631,6 +634,28 @@ module BoneInfo = struct
   let set_parent boneinfo parent = setf boneinfo BoneInfo.parent parent
 end
 
+module ModelSkeleton = struct
+  type t' = ModelSkeleton.t
+  type t = t' ctyp
+
+  let t = ModelSkeleton.t
+
+  let bone_count modelskeleton = getf modelskeleton ModelSkeleton.bone_count
+
+  let bones modelskeleton =
+    let count = getf modelskeleton ModelSkeleton.bone_count in
+    CArray.from_ptr (getf modelskeleton ModelSkeleton.bones) count
+
+  let bind_pose modelskeleton = getf modelskeleton ModelSkeleton.bind_pose
+
+  let set_bones modelskeleton bones =
+    setf modelskeleton ModelSkeleton.bones (CArray.start bones);
+    setf modelskeleton ModelSkeleton.bone_count (CArray.length bones)
+
+  let set_bind_pose modelskeleton bind_pose =
+    setf modelskeleton ModelSkeleton.bind_pose bind_pose
+end
+
 module Model = struct
   type t' = Model.t
   type t = t' ctyp
@@ -646,19 +671,29 @@ module Model = struct
     let count = getf model Model.material_count in
     CArray.from_ptr (getf model Model.materials) count
 
-  let bones model =
-    let count = getf model Model.bone_count in
-    CArray.from_ptr (getf model Model.bones) count
+  let skeleton model = getf model Model.skeleton
+  let current_pose model = getf model Model.current_pose
 
-  let bind_pose model = getf model Model.bind_pose
+  let bone_matrices model =
+    let skeleton = getf model Model.skeleton in
+    let count = ModelSkeleton.bone_count skeleton in
+    CArray.from_ptr (getf model Model.bone_matrices) count
+
   let set_transform model transform = setf model Model.transform transform
-  let set_meshes model meshes = setf model Model.meshes (CArray.start meshes)
+
+  let set_meshes model meshes =
+    setf model Model.meshes (CArray.start meshes);
+    setf model Model.mesh_count (CArray.length meshes)
 
   let set_materials model materials =
-    setf model Model.materials (CArray.start materials)
+    setf model Model.materials (CArray.start materials);
+    setf model Model.material_count (CArray.length materials)
 
-  let set_bones model bones = setf model Model.bones (CArray.start bones)
-  let set_bind_pose model bind_pose = setf model Model.bind_pose bind_pose
+  let set_current_pose model current_pose =
+    setf model Model.current_pose current_pose
+
+  let set_bone_matrices model bone_matrices =
+    setf model Model.bone_matrices (CArray.start bone_matrices)
 end
 
 module ModelAnimation = struct
@@ -667,27 +702,22 @@ module ModelAnimation = struct
 
   let t = ModelAnimation.t
 
-  let bones modelanimation =
-    let count = getf modelanimation ModelAnimation.bone_count in
-    CArray.from_ptr (getf modelanimation ModelAnimation.bones) count
-
-  let frame_count modelanimation =
-    getf modelanimation ModelAnimation.frame_count
-
   let name modelanimation =
     let ptr = Ctypes.CArray.start (getf modelanimation ModelAnimation.name) in
     Ctypes.string_from_ptr ptr ~length:32
 
-  let frame_poses_at anim index =
-    let frame_count = getf anim ModelAnimation.frame_count in
+  let bone_count modelanimation = getf modelanimation ModelAnimation.bone_count
+
+  let keyframe_count modelanimation =
+    getf modelanimation ModelAnimation.keyframe_count
+
+  let keyframe_poses_at anim index =
+    let keyframe_count = getf anim ModelAnimation.keyframe_count in
     let poses =
-      CArray.from_ptr (getf anim ModelAnimation.frame_poses) frame_count
+      CArray.from_ptr (getf anim ModelAnimation.keyframe_poses) keyframe_count
     in
     let bone_count = getf anim ModelAnimation.bone_count in
     CArray.from_ptr (CArray.get poses index) bone_count
-
-  let set_bones modelanimation bones =
-    setf modelanimation ModelAnimation.bones (CArray.start bones)
 end
 
 module Ray = struct
@@ -935,7 +965,6 @@ module FilePathList = struct
   type t = t' ctyp
 
   let t = FilePathList.t
-  let capacity filepathlist = getf filepathlist FilePathList.capacity
   let count filepathlist = getf filepathlist FilePathList.count
   let paths filepathlist = getf filepathlist FilePathList.paths
 
@@ -992,5 +1021,4 @@ module AutomationEventList = struct
     setf automationeventlist AutomationEventList.events events
 end
 
-let max_material_maps = max_material_maps
 let max_shader_locations = max_shader_locations

--- a/src/raylib/raylib_types.ml
+++ b/src/raylib/raylib_types.ml
@@ -584,7 +584,8 @@ module Material = struct
   let shader material = getf material Material.shader
 
   let maps material =
-    let max_material_maps = 12 in  (* no longer exported in Raylib 6.0! *)
+    (* no longer exported in Raylib 6.0! *)
+    let max_material_maps = 12 in
     CArray.from_ptr (getf material Material.maps) max_material_maps
 
   let params material = getf material Material.params
@@ -639,7 +640,6 @@ module ModelSkeleton = struct
   type t = t' ctyp
 
   let t = ModelSkeleton.t
-
   let bone_count modelskeleton = getf modelskeleton ModelSkeleton.bone_count
 
   let bones modelskeleton =

--- a/src/raylib/rlgl.mli
+++ b/src/raylib/rlgl.mli
@@ -129,9 +129,10 @@ val framebuffer_attach :
 
 val framebuffer_complete : Unsigned.uint -> bool
 val unload_framebuffer : Unsigned.uint -> unit
-val load_shader_code : string -> string -> Unsigned.uint
-val compile_shader : string -> int -> Unsigned.uint
-val load_shader_program : Unsigned.uint -> Unsigned.uint -> Unsigned.uint
+val load_shader_program : string -> string -> Unsigned.uint
+val load_shader : string -> int -> Unsigned.uint
+val load_shader_program_ex : Unsigned.uint -> Unsigned.uint -> Unsigned.uint
+val unload_shader : Unsigned.uint -> unit
 val unload_shader_program : Unsigned.uint -> unit
 val get_location_uniform : Unsigned.uint -> string -> int
 val get_location_attrib : Unsigned.uint -> string -> int

--- a/src/util/raylib_api.json
+++ b/src/util/raylib_api.json
@@ -9,13 +9,13 @@
     {
       "name": "RAYLIB_VERSION_MAJOR",
       "type": "INT",
-      "value": 5,
+      "value": 6,
       "description": ""
     },
     {
       "name": "RAYLIB_VERSION_MINOR",
       "type": "INT",
-      "value": 5,
+      "value": 0,
       "description": ""
     },
     {
@@ -27,7 +27,7 @@
     {
       "name": "RAYLIB_VERSION",
       "type": "STRING",
-      "value": "5.5",
+      "value": "6.0",
       "description": ""
     },
     {
@@ -40,7 +40,7 @@
       "name": "RLAPI",
       "type": "UNKNOWN",
       "value": "__declspec(dllexport)",
-      "description": "We are building the library as a Win32 shared library (.dll)"
+      "description": "Building the library as a Win32 shared library (.dll)"
     },
     {
       "name": "PI",
@@ -753,7 +753,7 @@
         {
           "type": "float",
           "name": "fovy",
-          "description": "Camera field-of-view aperture in Y (degrees) in perspective, used as near plane width in orthographic"
+          "description": "Camera field-of-view aperture in Y (degrees) in perspective, used as near plane height in world units in orthographic"
         },
         {
           "type": "int",
@@ -769,22 +769,22 @@
         {
           "type": "Vector2",
           "name": "offset",
-          "description": "Camera offset (displacement from target)"
+          "description": "Camera offset (screen space offset from window origin)"
         },
         {
           "type": "Vector2",
           "name": "target",
-          "description": "Camera target (rotation and zoom origin)"
+          "description": "Camera target (world space target point that is mapped to screen space offset)"
         },
         {
           "type": "float",
           "name": "rotation",
-          "description": "Camera rotation in degrees"
+          "description": "Camera rotation in degrees (pivots around target)"
         },
         {
           "type": "float",
           "name": "zoom",
-          "description": "Camera zoom (scaling), should be 1.0f by default"
+          "description": "Camera zoom (scaling around target), must not be set to 0, set to 1.0f for no scale"
         }
       ]
     },
@@ -838,6 +838,21 @@
           "description": "Vertex indices (in case vertex data comes indexed)"
         },
         {
+          "type": "int",
+          "name": "boneCount",
+          "description": "Number of bones (MAX: 256 bones)"
+        },
+        {
+          "type": "unsigned char *",
+          "name": "boneIndices",
+          "description": "Vertex bone indices, up to 4 bones influence by vertex (skinning) (shader-location = 6)"
+        },
+        {
+          "type": "float *",
+          "name": "boneWeights",
+          "description": "Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7)"
+        },
+        {
           "type": "float *",
           "name": "animVertices",
           "description": "Animated vertex positions (after bones transformations)"
@@ -846,26 +861,6 @@
           "type": "float *",
           "name": "animNormals",
           "description": "Animated normals (after bones transformations)"
-        },
-        {
-          "type": "unsigned char *",
-          "name": "boneIds",
-          "description": "Vertex bone ids, max 255 bone ids, up to 4 bones influence by vertex (skinning) (shader-location = 6)"
-        },
-        {
-          "type": "float *",
-          "name": "boneWeights",
-          "description": "Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7)"
-        },
-        {
-          "type": "Matrix *",
-          "name": "boneMatrices",
-          "description": "Bones animated transformation matrices"
-        },
-        {
-          "type": "int",
-          "name": "boneCount",
-          "description": "Number of bones"
         },
         {
           "type": "unsigned int",
@@ -975,6 +970,27 @@
       ]
     },
     {
+      "name": "ModelSkeleton",
+      "description": "Skeleton, animation bones hierarchy",
+      "fields": [
+        {
+          "type": "int",
+          "name": "boneCount",
+          "description": "Number of bones"
+        },
+        {
+          "type": "BoneInfo *",
+          "name": "bones",
+          "description": "Bones information (skeleton)"
+        },
+        {
+          "type": "ModelAnimPose",
+          "name": "bindPose",
+          "description": "Bones base transformation (Transform[])"
+        }
+      ]
+    },
+    {
       "name": "Model",
       "description": "Model, meshes, materials and animation data",
       "fields": [
@@ -1009,50 +1025,45 @@
           "description": "Mesh material number"
         },
         {
-          "type": "int",
-          "name": "boneCount",
-          "description": "Number of bones"
+          "type": "ModelSkeleton",
+          "name": "skeleton",
+          "description": "Skeleton for animation"
         },
         {
-          "type": "BoneInfo *",
-          "name": "bones",
-          "description": "Bones information (skeleton)"
+          "type": "ModelAnimPose",
+          "name": "currentPose",
+          "description": "Current animation pose (Transform[])"
         },
         {
-          "type": "Transform *",
-          "name": "bindPose",
-          "description": "Bones base transformation (pose)"
+          "type": "Matrix *",
+          "name": "boneMatrices",
+          "description": "Bones animated transformation matrices"
         }
       ]
     },
     {
       "name": "ModelAnimation",
-      "description": "ModelAnimation",
+      "description": "ModelAnimation, contains a full animation sequence",
       "fields": [
-        {
-          "type": "int",
-          "name": "boneCount",
-          "description": "Number of bones"
-        },
-        {
-          "type": "int",
-          "name": "frameCount",
-          "description": "Number of animation frames"
-        },
-        {
-          "type": "BoneInfo *",
-          "name": "bones",
-          "description": "Bones information (skeleton)"
-        },
-        {
-          "type": "Transform **",
-          "name": "framePoses",
-          "description": "Poses array by frame"
-        },
         {
           "type": "char[32]",
           "name": "name",
           "description": "Animation name"
+        },
+        {
+          "type": "int",
+          "name": "boneCount",
+          "description": "Number of bones (per pose)"
+        },
+        {
+          "type": "int",
+          "name": "keyframeCount",
+          "description": "Number of animation key frames"
+        },
+        {
+          "type": "ModelAnimPose *",
+          "name": "keyframePoses",
+          "description": "Animation sequence keyframe poses [keyframe][pose]"
         }
       ]
     },
@@ -1326,11 +1337,6 @@
       "fields": [
         {
           "type": "unsigned int",
-          "name": "capacity",
-          "description": "Filepaths max entries"
-        },
-        {
-          "type": "unsigned int",
           "name": "count",
           "description": "Filepaths entries count"
         },
@@ -1409,6 +1415,11 @@
       "type": "Camera3D",
       "name": "Camera",
       "description": "Camera type fallback, defaults to Camera3D"
+    },
+    {
+      "type": "Transform",
+      "name": "*ModelAnimPose",
+      "description": "Anim pose, an array of Transform[]"
     }
   ],
   "enums": [
@@ -2209,7 +2220,7 @@
         {
           "name": "GAMEPAD_BUTTON_UNKNOWN",
           "value": 0,
-          "description": "Unknown button, just for error checking"
+          "description": "Unknown button, for error checking"
         },
         {
           "name": "GAMEPAD_BUTTON_LEFT_FACE_UP",
@@ -2300,7 +2311,7 @@
     },
     {
       "name": "GamepadAxis",
-      "description": "Gamepad axis",
+      "description": "Gamepad axes",
       "values": [
         {
           "name": "GAMEPAD_AXIS_LEFT_X",
@@ -2507,7 +2518,7 @@
         {
           "name": "SHADER_LOC_MAP_HEIGHT",
           "value": 21,
-          "description": "Shader location: sampler2d texture: height"
+          "description": "Shader location: sampler2d texture: heightmap"
         },
         {
           "name": "SHADER_LOC_MAP_CUBEMAP",
@@ -2532,17 +2543,22 @@
         {
           "name": "SHADER_LOC_VERTEX_BONEIDS",
           "value": 26,
-          "description": "Shader location: vertex attribute: boneIds"
+          "description": "Shader location: vertex attribute: bone indices"
         },
         {
           "name": "SHADER_LOC_VERTEX_BONEWEIGHTS",
           "value": 27,
-          "description": "Shader location: vertex attribute: boneWeights"
+          "description": "Shader location: vertex attribute: bone weights"
         },
         {
-          "name": "SHADER_LOC_BONE_MATRICES",
+          "name": "SHADER_LOC_MATRIX_BONETRANSFORMS",
           "value": 28,
-          "description": "Shader location: array of matrices uniform: boneMatrices"
+          "description": "Shader location: matrix attribute: bone transforms (animation)"
+        },
+        {
+          "name": "SHADER_LOC_VERTEX_INSTANCETRANSFORM",
+          "value": 29,
+          "description": "Shader location: vertex attribute: instance transforms"
         }
       ]
     },
@@ -2591,8 +2607,28 @@
           "description": "Shader uniform type: ivec4 (4 int)"
         },
         {
-          "name": "SHADER_UNIFORM_SAMPLER2D",
+          "name": "SHADER_UNIFORM_UINT",
           "value": 8,
+          "description": "Shader uniform type: unsigned int"
+        },
+        {
+          "name": "SHADER_UNIFORM_UIVEC2",
+          "value": 9,
+          "description": "Shader uniform type: uivec2 (2 unsigned int)"
+        },
+        {
+          "name": "SHADER_UNIFORM_UIVEC3",
+          "value": 10,
+          "description": "Shader uniform type: uivec3 (3 unsigned int)"
+        },
+        {
+          "name": "SHADER_UNIFORM_UIVEC4",
+          "value": 11,
+          "description": "Shader uniform type: uivec4 (4 unsigned int)"
+        },
+        {
+          "name": "SHADER_UNIFORM_SAMPLER2D",
+          "value": 12,
           "description": "Shader uniform type: sampler2d"
         }
       ]
@@ -2756,7 +2792,7 @@
         {
           "name": "TEXTURE_FILTER_POINT",
           "value": 0,
-          "description": "No filter, just pixel approximation"
+          "description": "No filter, pixel approximation"
         },
         {
           "name": "TEXTURE_FILTER_BILINEAR",
@@ -3114,7 +3150,7 @@
           "name": "fileName"
         },
         {
-          "type": "char *",
+          "type": "const char *",
           "name": "text"
         }
       ]
@@ -3255,7 +3291,7 @@
     },
     {
       "name": "RestoreWindow",
-      "description": "Set window state: not minimized/maximized",
+      "description": "Restore window from being minimized/maximized",
       "returnType": "void"
     },
     {
@@ -3874,7 +3910,7 @@
     },
     {
       "name": "SetShaderValueTexture",
-      "description": "Set shader uniform value for texture (sampler2d)",
+      "description": "Set shader uniform value and bind the texture (sampler2d)",
       "returnType": "void",
       "params": [
         {
@@ -4167,6 +4203,17 @@
       ]
     },
     {
+      "name": "SetTraceLogLevel",
+      "description": "Set the current threshold (minimum) log level",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "int",
+          "name": "logLevel"
+        }
+      ]
+    },
+    {
       "name": "TraceLog",
       "description": "Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)",
       "returnType": "void",
@@ -4186,13 +4233,13 @@
       ]
     },
     {
-      "name": "SetTraceLogLevel",
-      "description": "Set the current threshold (minimum) log level",
+      "name": "SetTraceLogCallback",
+      "description": "Set custom trace log",
       "returnType": "void",
       "params": [
         {
-          "type": "int",
-          "name": "logLevel"
+          "type": "TraceLogCallback",
+          "name": "callback"
         }
       ]
     },
@@ -4230,61 +4277,6 @@
         {
           "type": "void *",
           "name": "ptr"
-        }
-      ]
-    },
-    {
-      "name": "SetTraceLogCallback",
-      "description": "Set custom trace log",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "TraceLogCallback",
-          "name": "callback"
-        }
-      ]
-    },
-    {
-      "name": "SetLoadFileDataCallback",
-      "description": "Set custom file binary data loader",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "LoadFileDataCallback",
-          "name": "callback"
-        }
-      ]
-    },
-    {
-      "name": "SetSaveFileDataCallback",
-      "description": "Set custom file binary data saver",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "SaveFileDataCallback",
-          "name": "callback"
-        }
-      ]
-    },
-    {
-      "name": "SetLoadFileTextCallback",
-      "description": "Set custom file text data loader",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "LoadFileTextCallback",
-          "name": "callback"
-        }
-      ]
-    },
-    {
-      "name": "SetSaveFileTextCallback",
-      "description": "Set custom file text data saver",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "SaveFileTextCallback",
-          "name": "callback"
         }
       ]
     },
@@ -4384,8 +4376,142 @@
           "name": "fileName"
         },
         {
-          "type": "char *",
+          "type": "const char *",
           "name": "text"
+        }
+      ]
+    },
+    {
+      "name": "SetLoadFileDataCallback",
+      "description": "Set custom file binary data loader",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "LoadFileDataCallback",
+          "name": "callback"
+        }
+      ]
+    },
+    {
+      "name": "SetSaveFileDataCallback",
+      "description": "Set custom file binary data saver",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "SaveFileDataCallback",
+          "name": "callback"
+        }
+      ]
+    },
+    {
+      "name": "SetLoadFileTextCallback",
+      "description": "Set custom file text data loader",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "LoadFileTextCallback",
+          "name": "callback"
+        }
+      ]
+    },
+    {
+      "name": "SetSaveFileTextCallback",
+      "description": "Set custom file text data saver",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "SaveFileTextCallback",
+          "name": "callback"
+        }
+      ]
+    },
+    {
+      "name": "FileRename",
+      "description": "Rename file (if exists)",
+      "returnType": "int",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        },
+        {
+          "type": "const char *",
+          "name": "fileRename"
+        }
+      ]
+    },
+    {
+      "name": "FileRemove",
+      "description": "Remove file (if exists)",
+      "returnType": "int",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        }
+      ]
+    },
+    {
+      "name": "FileCopy",
+      "description": "Copy file from one path to another, dstPath created if it doesn't exist",
+      "returnType": "int",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "srcPath"
+        },
+        {
+          "type": "const char *",
+          "name": "dstPath"
+        }
+      ]
+    },
+    {
+      "name": "FileMove",
+      "description": "Move file from one directory to another, dstPath created if it doesn't exist",
+      "returnType": "int",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "srcPath"
+        },
+        {
+          "type": "const char *",
+          "name": "dstPath"
+        }
+      ]
+    },
+    {
+      "name": "FileTextReplace",
+      "description": "Replace text in an existing file",
+      "returnType": "int",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        },
+        {
+          "type": "const char *",
+          "name": "search"
+        },
+        {
+          "type": "const char *",
+          "name": "replacement"
+        }
+      ]
+    },
+    {
+      "name": "FileTextFindIndex",
+      "description": "Find text in existing file",
+      "returnType": "int",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        },
+        {
+          "type": "const char *",
+          "name": "search"
         }
       ]
     },
@@ -4413,7 +4539,7 @@
     },
     {
       "name": "IsFileExtension",
-      "description": "Check file extension (including point: .png, .wav)",
+      "description": "Check file extension (recommended include point: .png, .wav)",
       "returnType": "bool",
       "params": [
         {
@@ -4430,6 +4556,17 @@
       "name": "GetFileLength",
       "description": "Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)",
       "returnType": "int",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        }
+      ]
+    },
+    {
+      "name": "GetFileModTime",
+      "description": "Get file modification time (last write time)",
+      "returnType": "long",
       "params": [
         {
           "type": "const char *",
@@ -4520,7 +4657,7 @@
       "params": [
         {
           "type": "const char *",
-          "name": "dir"
+          "name": "dirPath"
         }
       ]
     },
@@ -4548,7 +4685,7 @@
     },
     {
       "name": "LoadDirectoryFiles",
-      "description": "Load directory filepaths",
+      "description": "Load directory filepaths, files and directories, no subdirs scan",
       "returnType": "FilePathList",
       "params": [
         {
@@ -4559,7 +4696,7 @@
     },
     {
       "name": "LoadDirectoryFilesEx",
-      "description": "Load directory filepaths with extension filtering and recursive directory scan. Use 'DIR' in the filter string to include directories in the result",
+      "description": "Load directory filepaths with extension filtering and subdir scan; some filters available: `*.*`, `FILES*`, `DIRS*`",
       "returnType": "FilePathList",
       "params": [
         {
@@ -4609,13 +4746,32 @@
       ]
     },
     {
-      "name": "GetFileModTime",
-      "description": "Get file modification time (last write time)",
-      "returnType": "long",
+      "name": "GetDirectoryFileCount",
+      "description": "Get the file count in a directory",
+      "returnType": "unsigned int",
       "params": [
         {
           "type": "const char *",
-          "name": "fileName"
+          "name": "dirPath"
+        }
+      ]
+    },
+    {
+      "name": "GetDirectoryFileCountEx",
+      "description": "Get the file count in a directory with extension filtering and recursive directory scan. Use 'DIR' in the filter string to include directories in the result",
+      "returnType": "unsigned int",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "basePath"
+        },
+        {
+          "type": "const char *",
+          "name": "filter"
+        },
+        {
+          "type": "bool",
+          "name": "scanSubdirs"
         }
       ]
     },
@@ -4659,7 +4815,7 @@
     },
     {
       "name": "EncodeDataBase64",
-      "description": "Encode data to Base64 string, memory must be MemFree()",
+      "description": "Encode data to Base64 string (includes NULL terminator), memory must be MemFree()",
       "returnType": "char *",
       "params": [
         {
@@ -4678,12 +4834,12 @@
     },
     {
       "name": "DecodeDataBase64",
-      "description": "Decode Base64 string data, memory must be MemFree()",
+      "description": "Decode Base64 string (expected NULL terminated), memory must be MemFree()",
       "returnType": "unsigned char *",
       "params": [
         {
-          "type": "const unsigned char *",
-          "name": "data"
+          "type": "const char *",
+          "name": "text"
         },
         {
           "type": "int *",
@@ -4724,6 +4880,21 @@
     {
       "name": "ComputeSHA1",
       "description": "Compute SHA1 hash code, returns static int[5] (20 bytes)",
+      "returnType": "unsigned int *",
+      "params": [
+        {
+          "type": "unsigned char *",
+          "name": "data"
+        },
+        {
+          "type": "int",
+          "name": "dataSize"
+        }
+      ]
+    },
+    {
+      "name": "ComputeSHA256",
+      "description": "Compute SHA256 hash code, returns static int[8] (32 bytes)",
       "returnType": "unsigned int *",
       "params": [
         {
@@ -4882,6 +5053,17 @@
       "returnType": "int"
     },
     {
+      "name": "GetKeyName",
+      "description": "Get name of a QWERTY key on the current keyboard layout (eg returns string 'q' for KEY_A on an AZERTY keyboard)",
+      "returnType": "const char *",
+      "params": [
+        {
+          "type": "int",
+          "name": "key"
+        }
+      ]
+    },
+    {
       "name": "SetExitKey",
       "description": "Set a custom key to exit program (default is ESC)",
       "returnType": "void",
@@ -4981,7 +5163,7 @@
     },
     {
       "name": "GetGamepadAxisCount",
-      "description": "Get gamepad axis count for a gamepad",
+      "description": "Get axis count for a gamepad",
       "returnType": "int",
       "params": [
         {
@@ -4992,7 +5174,7 @@
     },
     {
       "name": "GetGamepadAxisMovement",
-      "description": "Get axis movement value for a gamepad axis",
+      "description": "Get movement value for a gamepad axis",
       "returnType": "float",
       "params": [
         {
@@ -5467,6 +5649,33 @@
       ]
     },
     {
+      "name": "DrawLineDashed",
+      "description": "Draw a dashed line",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "startPos"
+        },
+        {
+          "type": "Vector2",
+          "name": "endPos"
+        },
+        {
+          "type": "int",
+          "name": "dashSize"
+        },
+        {
+          "type": "int",
+          "name": "spaceSize"
+        },
+        {
+          "type": "Color",
+          "name": "color"
+        }
+      ]
+    },
+    {
       "name": "DrawCircle",
       "description": "Draw a color-filled circle",
       "returnType": "void",
@@ -5486,6 +5695,48 @@
         {
           "type": "Color",
           "name": "color"
+        }
+      ]
+    },
+    {
+      "name": "DrawCircleV",
+      "description": "Draw a color-filled circle (Vector version)",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "center"
+        },
+        {
+          "type": "float",
+          "name": "radius"
+        },
+        {
+          "type": "Color",
+          "name": "color"
+        }
+      ]
+    },
+    {
+      "name": "DrawCircleGradient",
+      "description": "Draw a gradient-filled circle",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "center"
+        },
+        {
+          "type": "float",
+          "name": "radius"
+        },
+        {
+          "type": "Color",
+          "name": "inner"
+        },
+        {
+          "type": "Color",
+          "name": "outer"
         }
       ]
     },
@@ -5544,52 +5795,6 @@
         {
           "type": "int",
           "name": "segments"
-        },
-        {
-          "type": "Color",
-          "name": "color"
-        }
-      ]
-    },
-    {
-      "name": "DrawCircleGradient",
-      "description": "Draw a gradient-filled circle",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "int",
-          "name": "centerX"
-        },
-        {
-          "type": "int",
-          "name": "centerY"
-        },
-        {
-          "type": "float",
-          "name": "radius"
-        },
-        {
-          "type": "Color",
-          "name": "inner"
-        },
-        {
-          "type": "Color",
-          "name": "outer"
-        }
-      ]
-    },
-    {
-      "name": "DrawCircleV",
-      "description": "Draw a color-filled circle (Vector version)",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "Vector2",
-          "name": "center"
-        },
-        {
-          "type": "float",
-          "name": "radius"
         },
         {
           "type": "Color",
@@ -5667,6 +5872,29 @@
       ]
     },
     {
+      "name": "DrawEllipseV",
+      "description": "Draw ellipse (Vector version)",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "center"
+        },
+        {
+          "type": "float",
+          "name": "radiusH"
+        },
+        {
+          "type": "float",
+          "name": "radiusV"
+        },
+        {
+          "type": "Color",
+          "name": "color"
+        }
+      ]
+    },
+    {
       "name": "DrawEllipseLines",
       "description": "Draw ellipse outline",
       "returnType": "void",
@@ -5678,6 +5906,29 @@
         {
           "type": "int",
           "name": "centerY"
+        },
+        {
+          "type": "float",
+          "name": "radiusH"
+        },
+        {
+          "type": "float",
+          "name": "radiusV"
+        },
+        {
+          "type": "Color",
+          "name": "color"
+        }
+      ]
+    },
+    {
+      "name": "DrawEllipseLinesV",
+      "description": "Draw ellipse outline (Vector version)",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "center"
         },
         {
           "type": "float",
@@ -5928,11 +6179,11 @@
         },
         {
           "type": "Color",
-          "name": "topRight"
+          "name": "bottomRight"
         },
         {
           "type": "Color",
-          "name": "bottomRight"
+          "name": "topRight"
         }
       ]
     },
@@ -6976,7 +7227,7 @@
     },
     {
       "name": "ExportImageToMemory",
-      "description": "Export image to memory buffer",
+      "description": "Export image to memory buffer, memory must be MemFree()",
       "returnType": "unsigned char *",
       "params": [
         {
@@ -8220,7 +8471,7 @@
           "name": "dst"
         },
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -8243,7 +8494,7 @@
           "name": "dst"
         },
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -8447,7 +8698,7 @@
     },
     {
       "name": "UpdateTexture",
-      "description": "Update GPU texture with new data",
+      "description": "Update GPU texture with new data (pixels should be able to fill texture)",
       "returnType": "void",
       "params": [
         {
@@ -8462,7 +8713,7 @@
     },
     {
       "name": "UpdateTextureRec",
-      "description": "Update GPU texture rectangle with new data",
+      "description": "Update GPU texture rectangle with new data (pixels and rec should fit in texture)",
       "returnType": "void",
       "params": [
         {
@@ -8959,7 +9210,7 @@
           "name": "fontSize"
         },
         {
-          "type": "int *",
+          "type": "const int *",
           "name": "codepoints"
         },
         {
@@ -9009,7 +9260,7 @@
           "name": "fontSize"
         },
         {
-          "type": "int *",
+          "type": "const int *",
           "name": "codepoints"
         },
         {
@@ -9047,7 +9298,7 @@
           "name": "fontSize"
         },
         {
-          "type": "int *",
+          "type": "const int *",
           "name": "codepoints"
         },
         {
@@ -9057,6 +9308,10 @@
         {
           "type": "int",
           "name": "type"
+        },
+        {
+          "type": "int *",
+          "name": "glyphCount"
         }
       ]
     },
@@ -9356,6 +9611,33 @@
       ]
     },
     {
+      "name": "MeasureTextCodepoints",
+      "description": "Measure string size for an existing array of codepoints for Font",
+      "returnType": "Vector2",
+      "params": [
+        {
+          "type": "Font",
+          "name": "font"
+        },
+        {
+          "type": "const int *",
+          "name": "codepoints"
+        },
+        {
+          "type": "int",
+          "name": "length"
+        },
+        {
+          "type": "float",
+          "name": "fontSize"
+        },
+        {
+          "type": "float",
+          "name": "spacing"
+        }
+      ]
+    },
+    {
       "name": "GetGlyphIndex",
       "description": "Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found",
       "returnType": "int",
@@ -9524,6 +9806,36 @@
       ]
     },
     {
+      "name": "LoadTextLines",
+      "description": "Load text as separate lines ('\\n')",
+      "returnType": "char **",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        },
+        {
+          "type": "int *",
+          "name": "count"
+        }
+      ]
+    },
+    {
+      "name": "UnloadTextLines",
+      "description": "Unload text lines",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "char **",
+          "name": "text"
+        },
+        {
+          "type": "int",
+          "name": "lineCount"
+        }
+      ]
+    },
+    {
       "name": "TextCopy",
       "description": "Copy one string to another, returns bytes copied",
       "returnType": "int",
@@ -9599,8 +9911,19 @@
       ]
     },
     {
-      "name": "TextReplace",
-      "description": "Replace text string (WARNING: memory must be freed!)",
+      "name": "TextRemoveSpaces",
+      "description": "Remove text spaces, concat words",
+      "returnType": "const char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        }
+      ]
+    },
+    {
+      "name": "GetTextBetween",
+      "description": "Get text between two strings",
       "returnType": "char *",
       "params": [
         {
@@ -9609,17 +9932,120 @@
         },
         {
           "type": "const char *",
-          "name": "replace"
+          "name": "begin"
         },
         {
           "type": "const char *",
-          "name": "by"
+          "name": "end"
+        }
+      ]
+    },
+    {
+      "name": "TextReplace",
+      "description": "Replace text string with new string",
+      "returnType": "char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        },
+        {
+          "type": "const char *",
+          "name": "search"
+        },
+        {
+          "type": "const char *",
+          "name": "replacement"
+        }
+      ]
+    },
+    {
+      "name": "TextReplaceAlloc",
+      "description": "Replace text string with new string, memory must be MemFree()",
+      "returnType": "char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        },
+        {
+          "type": "const char *",
+          "name": "search"
+        },
+        {
+          "type": "const char *",
+          "name": "replacement"
+        }
+      ]
+    },
+    {
+      "name": "TextReplaceBetween",
+      "description": "Replace text between two specific strings",
+      "returnType": "char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        },
+        {
+          "type": "const char *",
+          "name": "begin"
+        },
+        {
+          "type": "const char *",
+          "name": "end"
+        },
+        {
+          "type": "const char *",
+          "name": "replacement"
+        }
+      ]
+    },
+    {
+      "name": "TextReplaceBetweenAlloc",
+      "description": "Replace text between two specific strings, memory must be MemFree()",
+      "returnType": "char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        },
+        {
+          "type": "const char *",
+          "name": "begin"
+        },
+        {
+          "type": "const char *",
+          "name": "end"
+        },
+        {
+          "type": "const char *",
+          "name": "replacement"
         }
       ]
     },
     {
       "name": "TextInsert",
-      "description": "Insert text in a position (WARNING: memory must be freed!)",
+      "description": "Insert text in a defined byte position",
+      "returnType": "char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        },
+        {
+          "type": "const char *",
+          "name": "insert"
+        },
+        {
+          "type": "int",
+          "name": "position"
+        }
+      ]
+    },
+    {
+      "name": "TextInsertAlloc",
+      "description": "Insert text in a defined byte position, memory must be MemFree()",
       "returnType": "char *",
       "params": [
         {
@@ -9639,10 +10065,10 @@
     {
       "name": "TextJoin",
       "description": "Join text strings with delimiter",
-      "returnType": "const char *",
+      "returnType": "char *",
       "params": [
         {
-          "type": "const char **",
+          "type": "char **",
           "name": "textList"
         },
         {
@@ -9657,8 +10083,8 @@
     },
     {
       "name": "TextSplit",
-      "description": "Split text into multiple strings",
-      "returnType": "const char **",
+      "description": "Split text into multiple strings, using MAX_TEXTSPLIT_COUNT static strings",
+      "returnType": "char **",
       "params": [
         {
           "type": "const char *",
@@ -9676,7 +10102,7 @@
     },
     {
       "name": "TextAppend",
-      "description": "Append text at specific position and move cursor!",
+      "description": "Append text at specific position and move cursor",
       "returnType": "void",
       "params": [
         {
@@ -9695,7 +10121,7 @@
     },
     {
       "name": "TextFindIndex",
-      "description": "Find first text occurrence within a string",
+      "description": "Find first text occurrence within a string, -1 if not found",
       "returnType": "int",
       "params": [
         {
@@ -9704,14 +10130,14 @@
         },
         {
           "type": "const char *",
-          "name": "find"
+          "name": "search"
         }
       ]
     },
     {
       "name": "TextToUpper",
       "description": "Get upper case version of provided string",
-      "returnType": "const char *",
+      "returnType": "char *",
       "params": [
         {
           "type": "const char *",
@@ -9722,7 +10148,7 @@
     {
       "name": "TextToLower",
       "description": "Get lower case version of provided string",
-      "returnType": "const char *",
+      "returnType": "char *",
       "params": [
         {
           "type": "const char *",
@@ -9733,7 +10159,7 @@
     {
       "name": "TextToPascal",
       "description": "Get Pascal case notation version of provided string",
-      "returnType": "const char *",
+      "returnType": "char *",
       "params": [
         {
           "type": "const char *",
@@ -9744,7 +10170,7 @@
     {
       "name": "TextToSnake",
       "description": "Get Snake case notation version of provided string",
-      "returnType": "const char *",
+      "returnType": "char *",
       "params": [
         {
           "type": "const char *",
@@ -9755,7 +10181,7 @@
     {
       "name": "TextToCamel",
       "description": "Get Camel case notation version of provided string",
-      "returnType": "const char *",
+      "returnType": "char *",
       "params": [
         {
           "type": "const char *",
@@ -9765,7 +10191,7 @@
     },
     {
       "name": "TextToInteger",
-      "description": "Get integer value from text (negative values not supported)",
+      "description": "Get integer value from text",
       "returnType": "int",
       "params": [
         {
@@ -9776,7 +10202,7 @@
     },
     {
       "name": "TextToFloat",
-      "description": "Get float value from text (negative values not supported)",
+      "description": "Get float value from text",
       "returnType": "float",
       "params": [
         {
@@ -10452,60 +10878,6 @@
       ]
     },
     {
-      "name": "DrawModelPoints",
-      "description": "Draw a model as points",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "Model",
-          "name": "model"
-        },
-        {
-          "type": "Vector3",
-          "name": "position"
-        },
-        {
-          "type": "float",
-          "name": "scale"
-        },
-        {
-          "type": "Color",
-          "name": "tint"
-        }
-      ]
-    },
-    {
-      "name": "DrawModelPointsEx",
-      "description": "Draw a model as points with extended parameters",
-      "returnType": "void",
-      "params": [
-        {
-          "type": "Model",
-          "name": "model"
-        },
-        {
-          "type": "Vector3",
-          "name": "position"
-        },
-        {
-          "type": "Vector3",
-          "name": "rotationAxis"
-        },
-        {
-          "type": "float",
-          "name": "rotationAngle"
-        },
-        {
-          "type": "Vector3",
-          "name": "scale"
-        },
-        {
-          "type": "Color",
-          "name": "tint"
-        }
-      ]
-    },
-    {
       "name": "DrawBoundingBox",
       "description": "Draw bounding box (wires)",
       "returnType": "void",
@@ -11074,7 +11446,7 @@
     },
     {
       "name": "UpdateModelAnimation",
-      "description": "Update model animation pose (CPU)",
+      "description": "Update model animation pose (vertex buffers and bone matrices)",
       "returnType": "void",
       "params": [
         {
@@ -11086,14 +11458,14 @@
           "name": "anim"
         },
         {
-          "type": "int",
+          "type": "float",
           "name": "frame"
         }
       ]
     },
     {
-      "name": "UpdateModelAnimationBones",
-      "description": "Update model animation mesh bone matrices (GPU skinning)",
+      "name": "UpdateModelAnimationEx",
+      "description": "Update model animation pose, blending two animations",
       "returnType": "void",
       "params": [
         {
@@ -11102,22 +11474,23 @@
         },
         {
           "type": "ModelAnimation",
-          "name": "anim"
+          "name": "animA"
         },
         {
-          "type": "int",
-          "name": "frame"
-        }
-      ]
-    },
-    {
-      "name": "UnloadModelAnimation",
-      "description": "Unload animation data",
-      "returnType": "void",
-      "params": [
+          "type": "float",
+          "name": "frameA"
+        },
         {
           "type": "ModelAnimation",
-          "name": "anim"
+          "name": "animB"
+        },
+        {
+          "type": "float",
+          "name": "frameB"
+        },
+        {
+          "type": "float",
+          "name": "blend"
         }
       ]
     },
@@ -11429,7 +11802,7 @@
     },
     {
       "name": "UpdateSound",
-      "description": "Update sound buffer with new data",
+      "description": "Update sound buffer with new data (default data format: 32 bit float, stereo)",
       "returnType": "void",
       "params": [
         {
@@ -11596,7 +11969,7 @@
     },
     {
       "name": "SetSoundPan",
-      "description": "Set pan for a sound (0.5 is center)",
+      "description": "Set pan for a sound (-1.0 left, 0.0 center, 1.0 right)",
       "returnType": "void",
       "params": [
         {
@@ -11849,7 +12222,7 @@
     },
     {
       "name": "SetMusicPan",
-      "description": "Set pan for a music (0.5 is center)",
+      "description": "Set pan for a music (-1.0 left, 0.0 center, 1.0 right)",
       "returnType": "void",
       "params": [
         {
@@ -12042,7 +12415,7 @@
     },
     {
       "name": "SetAudioStreamPan",
-      "description": "Set pan for audio stream (0.5 is centered)",
+      "description": "Set pan for audio stream (-1.0 to 1.0 range, 0.0 is centered)",
       "returnType": "void",
       "params": [
         {
@@ -12083,7 +12456,7 @@
     },
     {
       "name": "AttachAudioStreamProcessor",
-      "description": "Attach audio stream processor to stream, receives the samples as 'float'",
+      "description": "Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)",
       "returnType": "void",
       "params": [
         {
@@ -12113,7 +12486,7 @@
     },
     {
       "name": "AttachAudioMixedProcessor",
-      "description": "Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'",
+      "description": "Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)",
       "returnType": "void",
       "params": [
         {

--- a/src/util/raylib_gen.ml
+++ b/src/util/raylib_gen.ml
@@ -553,7 +553,6 @@ let () =
     ^ (enums |> List.map Enum.stubs |> String.concat "")
     ^ (types |> List.map Type.stub |> String.concat "")
     ^ "end\n"
-    ^ "let max_material_maps = [%c constant \"MAX_MATERIAL_MAPS\" camlint]\n\n"
     ^ "let max_shader_locations = [%c constant \"MAX_SHADER_LOCATIONS\" \
        camlint]"
   in
@@ -565,7 +564,7 @@ let () =
   let itf =
     "(** {1 Constants} *)\n\n"
     ^ (enums |> List.map Enum.itf |> String.concat "")
-    ^ "val max_material_maps : int\n\n" ^ "val max_shader_locations : int\n\n"
+    ^ "val max_shader_locations : int\n\n"
   in
   (* print_string itf; *)
   ignore itf;


### PR DESCRIPTION
My attempt to upgrade the binding to Raylib 6.0, as released a few weeks ago.

The API changes are mostly additions, with the notable exception of some refactoring around the Model struct.

I also fixed a few bugs where the conversion between ptrs and strings or arrays wasn't quite right wrt memory management, and removed a few string-related functions that make no sense in OCaml or are outright wrong (e.g., TextCopy, TextAppend).

It builds fine. I tested various examples, especially those that might be affected by the API changes. It turns out some of them don't work (index out of bounds for model_animations, and mostly empty screen for a couple of other model examples). But going back to the released version, they don't work there either. I tried to go back further to 1.4.0, but it no longer builds with up-to-date opam dependencies, so I didn't pursue. Not sure what to do about these, is that a known issue?