### PR TITLE
Hotfix patches for UnloadMusicStream and GetWindowPosition

### DIFF
--- a/src/c/dune
+++ b/src/c/dune
@@ -28,6 +28,7 @@
  (deps
   (source_tree vendor/raylib)
   enable_formats.patch
+  hotfixes.patch
   apply_patch.exe
   chmodx.exe)
  (action
@@ -35,6 +36,9 @@
    (progn
     (run ./chmodx.exe vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run ./chmodx.exe vendor/raylib/src/platforms/rcore_desktop_glfw.c)
+    (run ./chmodx.exe vendor/raylib/src/raudio.c)
+    (run ./apply_patch.exe hotfixes.patch)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
@@ -49,6 +53,7 @@
  (deps
   (source_tree vendor/raylib)
   enable_formats.patch
+  hotfixes.patch
   apply_patch.exe
   chmodx.exe)
  (action
@@ -56,6 +61,9 @@
    (progn
     (run ./chmodx.exe vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run ./chmodx.exe vendor/raylib/src/platforms/rcore_desktop_glfw.c)
+    (run ./chmodx.exe vendor/raylib/src/raudio.c)
+    (run ./apply_patch.exe hotfixes.patch)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
@@ -72,6 +80,7 @@
  (deps
   (source_tree vendor/raylib)
   enable_formats.patch
+  hotfixes.patch
   mingw64.patch
   apply_patch.exe
   chmodx.exe)
@@ -80,6 +89,9 @@
    (progn
     (run ./chmodx.exe vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run ./chmodx.exe vendor/raylib/src/platforms/rcore_desktop_glfw.c)
+    (run ./chmodx.exe vendor/raylib/src/raudio.c)
+    (run ./apply_patch.exe hotfixes.patch)
     (run ./chmodx.exe vendor/raylib/src/Makefile)
     (run ./apply_patch.exe mingw64.patch)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)
@@ -98,6 +110,7 @@
  (deps
   (source_tree vendor/raylib)
   enable_formats.patch
+  hotfixes.patch
   msys2.patch
   apply_patch.exe
   chmodx.exe)
@@ -106,6 +119,9 @@
    (progn
     (run ./chmodx.exe vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run ./chmodx.exe vendor/raylib/src/platforms/rcore_desktop_glfw.c)
+    (run ./chmodx.exe vendor/raylib/src/raudio.c)
+    (run ./apply_patch.exe hotfixes.patch)
     (run ./chmodx.exe vendor/raylib/src/Makefile)
     (run ./apply_patch.exe msys2.patch)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)
@@ -127,6 +143,7 @@
  (deps
   (source_tree vendor/raylib)
   enable_formats.patch
+  hotfixes.patch
   freebsd.patch
   apply_patch.exe
   chmodx.exe)
@@ -135,6 +152,9 @@
    (progn
     (run ./chmodx.exe vendor/raylib/src/config.h)
     (run ./apply_patch.exe enable_formats.patch)
+    (run ./chmodx.exe vendor/raylib/src/platforms/rcore_desktop_glfw.c)
+    (run ./chmodx.exe vendor/raylib/src/raudio.c)
+    (run ./apply_patch.exe hotfixes.patch)
     (run ./chmodx.exe vendor/raylib/src/Makefile)
     (run ./apply_patch.exe freebsd.patch)
     (run gmake -C vendor/raylib/src RAYLIB_LIBTYPE=STATIC -j 8)

--- a/src/c/hotfixes.patch
+++ b/src/c/hotfixes.patch
@@ -1,0 +1,25 @@
+diff --git a/vendor/raylib/src/platforms/rcore_desktop_glfw.c b/vendor/raylib/src/platforms/rcore_desktop_glfw.c
+index 55b92ac7..b45cd1cb 100644
+--- a/vendor/raylib/src/platforms/rcore_desktop_glfw.c
++++ b/vendor/raylib/src/platforms/rcore_desktop_glfw.c
+@@ -2015,6 +2015,7 @@ static void WindowMaximizeCallback(GLFWwindow *window, int maximized)
+ {
+     if (maximized) FLAG_SET(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED);  // The window was maximized
+     else FLAG_CLEAR(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED);          // The window was restored
++    glfwGetWindowPos(window, &CORE.Window.position.x, &CORE.Window.position.y);
+ }
+ 
+ // GLFW3: Window focus callback, runs when window get/lose focus
+diff --git a/vendor/raylib/src/raudio.c b/vendor/raylib/src/raudio.c
+index 55b92ac7..b45cd1cb 100644
+--- a/vendor/raylib/src/raudio.c
++++ b/vendor/raylib/src/raudio.c
+@@ -1782,7 +1782,7 @@ void UnloadMusicStream(Music music)
+         else if (music.ctxType == MUSIC_AUDIO_QOA) qoaplay_close((qoaplay_desc *)music.ctxData);
+ #endif
+ #if SUPPORT_FILEFORMAT_FLAC
+-        else if (music.ctxType == MUSIC_AUDIO_FLAC) { drflac_close((drflac *)music.ctxData); drflac_free((drflac *)music.ctxData, NULL); }
++        else if (music.ctxType == MUSIC_AUDIO_FLAC) drflac_close((drflac *)music.ctxData);
+ #endif
+ #if SUPPORT_FILEFORMAT_XM
+         else if (music.ctxType == MUSIC_MODULE_XM) jar_xm_free_context((jar_xm_context_t *)music.ctxData);


### PR DESCRIPTION
This adds a patch file that fixes two upstream regressions that I ran into with Raylib 6.0. This is sort of cherry-picking the one-line fixes from post-release.

* One causes a crash / abrupt termination when calling unload_music_stream on an opened FLAC file.
* The other lets get_window_position report the wrong values after maximize_window on some platforms (esp MacOS).

Hope it is okay to sneak that in here. With Raylib's slow release cycle, I expect it will take a long time for them to land in a new release. :)