### PR TITLE
Fix patcher to apply all diffs

### DIFF
--- a/src/c/apply_patch.ml
+++ b/src/c/apply_patch.ml
@@ -2,27 +2,12 @@
    goes wrong with opening the file or patching, we want the execution to fail.
    There is no straying from the happy path. *)
 
-let invert_hunk (hunk : Patch.hunk) : Patch.hunk =
-  { mine_start = hunk.their_start;
-    mine_len = hunk.their_len;
-    mine = hunk.their;
-    their_start = hunk.mine_start;
-    their_len = hunk.mine_len;
-    their = hunk.mine }
-
-let invert (patch : Patch.t) : Patch.t =
-  { patch with
-    hunks = List.map invert_hunk patch.hunks;
-    mine_no_nl = patch.their_no_nl;
-    their_no_nl = patch.mine_no_nl }
-
-let patch file reverse =
+let patch file =
   let patch_ic = open_in_bin file in
   let s = really_input_string patch_ic (in_channel_length patch_ic) in
   close_in patch_ic;
 
   let patches = Patch.parse ~p:1 s in
-  let patches' = if reverse then List.map invert patches else patches in
   List.iter (fun (patch : Patch.t) ->
     let target =
       match patch.operation with
@@ -30,7 +15,7 @@ let patch file reverse =
       | _ -> failwith "We only do edits"
     in
 
-    print_endline ((if reverse then "reverse " else "") ^ "patching " ^ target);
+    print_endline ("patching " ^ target);
 
     let input_ic = open_in_bin target in
     let input = really_input_string input_ic (in_channel_length input_ic) in
@@ -45,6 +30,6 @@ let patch file reverse =
     output_string oc output;
     flush oc;
     close_out oc
-  ) patches'
+  ) patches
 
-let () = patch Sys.argv.(1) (Array.length Sys.argv > 2 && Sys.argv.(2) = "-r")
+let () = patch Sys.argv.(1)

--- a/src/c/apply_patch.ml
+++ b/src/c/apply_patch.ml
@@ -2,32 +2,49 @@
    goes wrong with opening the file or patching, we want the execution to fail.
    There is no straying from the happy path. *)
 
-let patch file =
+let invert_hunk (hunk : Patch.hunk) : Patch.hunk =
+  { mine_start = hunk.their_start;
+    mine_len = hunk.their_len;
+    mine = hunk.their;
+    their_start = hunk.mine_start;
+    their_len = hunk.mine_len;
+    their = hunk.mine }
+
+let invert (patch : Patch.t) : Patch.t =
+  { patch with
+    hunks = List.map invert_hunk patch.hunks;
+    mine_no_nl = patch.their_no_nl;
+    their_no_nl = patch.mine_no_nl }
+
+let patch file reverse =
   let patch_ic = open_in_bin file in
   let s = really_input_string patch_ic (in_channel_length patch_ic) in
   close_in patch_ic;
 
-  let patch = Patch.parse ~p:1 s |> List.hd in
-  let target =
-    match patch.operation with
-    | Edit (a, _) -> String.trim a
-    | _ -> failwith "We only do edits"
-  in
-  print_endline target;
-  let input_ic = open_in_bin target in
-  let input = really_input_string input_ic (in_channel_length input_ic) in
-  close_in input_ic;
+  let patches = Patch.parse ~p:1 s in
+  let patches' = if reverse then List.map invert patches else patches in
+  List.iter (fun (patch : Patch.t) ->
+    let target =
+      match patch.operation with
+      | Edit (a, _) -> String.trim a
+      | _ -> failwith "We only do edits"
+    in
 
-  print_endline ("patching " ^ target);
+    print_endline ((if reverse then "reverse " else "") ^ "patching " ^ target);
 
-  let output =
-    match Patch.patch ~cleanly:true (Some input) patch with
-    | Some output -> output
-    | None -> failwith "Patch does not apply"
-  in
-  let oc = open_out_bin target in
-  output_string oc output;
-  flush oc;
-  close_out oc
+    let input_ic = open_in_bin target in
+    let input = really_input_string input_ic (in_channel_length input_ic) in
+    close_in input_ic;
 
-let () = patch (Array.get Sys.argv 1)
+    let output =
+      match Patch.patch ~cleanly:true (Some input) patch with
+      | Some output -> output
+      | None -> failwith "Patch does not apply"
+    in
+    let oc = open_out_bin target in
+    output_string oc output;
+    flush oc;
+    close_out oc
+  ) patches'
+
+let () = patch Sys.argv.(1) (Array.length Sys.argv > 2 && Sys.argv.(2) = "-r")

--- a/src/c/dune
+++ b/src/c/dune
@@ -43,7 +43,9 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.so.6.0.0 dllraylib.so)))))
+    (copy vendor/raylib/src/libraylib.so.6.0.0 dllraylib.so)
+    (run ./apply_patch.exe enable_formats.patch -r)
+    (run ./apply_patch.exe hotfixes.patch -r)))))
 
 (rule
  (alias build-raylib)
@@ -68,7 +70,9 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.6.0.0.dylib dllraylib.so)))))
+    (copy vendor/raylib/src/libraylib.6.0.0.dylib dllraylib.so)
+    (run ./apply_patch.exe enable_formats.patch -r)
+    (run ./apply_patch.exe hotfixes.patch -r)))))
 
 (rule
  (alias build-raylib)
@@ -98,7 +102,10 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/raylib.dll dllraylib.dll)))))
+    (copy vendor/raylib/src/raylib.dll dllraylib.dll)
+    (run ./apply_patch.exe enable_formats.patch -r)
+    (run ./apply_patch.exe hotfixes.patch -r)
+    (run ./apply_patch.exe mingw64.patch -r)))))
 
 (rule
  (alias build-raylib)
@@ -128,7 +135,10 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/raylib.dll dllraylib.dll)))))
+    (copy vendor/raylib/src/raylib.dll dllraylib.dll)
+    (run ./apply_patch.exe qenable_formats.patch -r)
+    (run ./apply_patch.exe hotfixes.patch -r)
+    (run ./apply_patch.exe msys2.patch -r)))))
 
 (rule
  (alias build-raylib)
@@ -161,4 +171,7 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run gmake -C vendor/raylib/src clean)
     (run gmake -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.6.0.0.so dllraylib.so)))))
+    (copy vendor/raylib/src/libraylib.6.0.0.so dllraylib.so)
+    (run ./apply_patch.exe enable_formats.patch -r)
+    (run ./apply_patch.exe hotfixes.patch -r)
+    (run ./apply_patch.exe freebsd.patch -r)))))

--- a/src/c/dune
+++ b/src/c/dune
@@ -43,9 +43,7 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.so.6.0.0 dllraylib.so)
-    (run ./apply_patch.exe enable_formats.patch -r)
-    (run ./apply_patch.exe hotfixes.patch -r)))))
+    (copy vendor/raylib/src/libraylib.so.6.0.0 dllraylib.so)))))
 
 (rule
  (alias build-raylib)
@@ -70,9 +68,7 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.6.0.0.dylib dllraylib.so)
-    (run ./apply_patch.exe enable_formats.patch -r)
-    (run ./apply_patch.exe hotfixes.patch -r)))))
+    (copy vendor/raylib/src/libraylib.6.0.0.dylib dllraylib.so)))))
 
 (rule
  (alias build-raylib)
@@ -102,10 +98,7 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/raylib.dll dllraylib.dll)
-    (run ./apply_patch.exe enable_formats.patch -r)
-    (run ./apply_patch.exe hotfixes.patch -r)
-    (run ./apply_patch.exe mingw64.patch -r)))))
+    (copy vendor/raylib/src/raylib.dll dllraylib.dll)))))
 
 (rule
  (alias build-raylib)
@@ -135,10 +128,7 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run make -C vendor/raylib/src clean)
     (run make -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/raylib.dll dllraylib.dll)
-    (run ./apply_patch.exe qenable_formats.patch -r)
-    (run ./apply_patch.exe hotfixes.patch -r)
-    (run ./apply_patch.exe msys2.patch -r)))))
+    (copy vendor/raylib/src/raylib.dll dllraylib.dll)))))
 
 (rule
  (alias build-raylib)
@@ -171,7 +161,4 @@
     (copy vendor/raylib/src/libraylib.a libraylib.a)
     (run gmake -C vendor/raylib/src clean)
     (run gmake -C vendor/raylib/src RAYLIB_LIBTYPE=SHARED -j 8)
-    (copy vendor/raylib/src/libraylib.6.0.0.so dllraylib.so)
-    (run ./apply_patch.exe enable_formats.patch -r)
-    (run ./apply_patch.exe hotfixes.patch -r)
-    (run ./apply_patch.exe freebsd.patch -r)))))
+    (copy vendor/raylib/src/libraylib.6.0.0.so dllraylib.so)))))


### PR DESCRIPTION
Tweak the apply_patch helper to apply all diffs instead of just the first one. In addition, reverse all patches after each build. That's useful to make `dune build` repeatable, especially when experimenting with patches.

I only noticed with the release of 2.2.0 that half of my hotfix from #79 wasn’t actually having any effect. I had tested the patch manually on both Win and Mac, and then made sure that the dune recipe builds correctly on both, but hadn’t retested the result on Windows, only on Mac. As a result, I only saw that the first patch (which is observable on Mac) worked, but not that the second (which is only observable on Win) didn’t. It had never occurred to me that only half of the patch might have been applied by the build!

Consequently, playing flacs still crashes on Windows in 2.2.0, and we may need a 2.2.1 release with this fix. :)
