### PR TITLE
Support DragonFly BSD

### DIFF
--- a/src/c/config/configure.ml
+++ b/src/c/config/configure.ml
@@ -14,7 +14,7 @@ let () =
             link ~flag:"-framework"
               [ "OpenGL"; "Cocoa"; "IOKit"; "CoreAudio"; "CoreVideo" ]
         | Some "mingw64" -> link [ "opengl32"; "gdi32"; "winmm"; "pthread" ]
-        | Some ("netbsd" | "freebsd" | "openbsd" | "bsd" | "bsd_elf") ->
+        | Some ("netbsd" | "freebsd" | "openbsd" | "dragonfly" | "bsd" | "bsd_elf") ->
             "-cclib" :: "-L /usr/local/lib"
             :: link
                  [

--- a/src/c/dune
+++ b/src/c/dune
@@ -122,6 +122,7 @@
    (= %{system} netbsd)
    (= %{system} freebsd)
    (= %{system} openbsd)
+   (= %{system} dragonfly)
    (= %{system} bsd)
    (= %{system} bsd_elf)))
  (deps

--- a/src/c/freebsd.patch
+++ b/src/c/freebsd.patch
@@ -1,11 +1,39 @@
 diff -u a/vendor/raylib/src/Makefile b/vendor/raylib/src/Makefile
 --- a/vendor/raylib/src/Makefile
 +++ b/vendor/raylib/src/Makefile
-@@ -402,6 +402,7 @@ ifeq ($(RAYLIB_BUILD_MODE),RELEASE)
+@@ -310,9 +310,12 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
+         GLFW_OSX = -x objective-c
      endif
-     ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+     ifeq ($(PLATFORM_OS),BSD)
+-        # FreeBSD, OpenBSD, NetBSD, DragonFly default compiler
++        # FreeBSD, OpenBSD, NetBSD default compiler
+         CC = clang
+     endif
++    ifeq ($(shell uname),DragonFly)
++        CC = gcc
++    endif
+ endif
+ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_RGFW)
+     ifeq ($(PLATFORM_OS),OSX)
+@@ -321,9 +324,12 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_RGFW)
+         GLFW_OSX = -x objective-c
+     endif
+     ifeq ($(PLATFORM_OS),BSD)
+-        # FreeBSD, OpenBSD, NetBSD, DragonFly default compiler
++        # FreeBSD, OpenBSD, NetBSD default compiler
+         CC = clang
+     endif
++    ifeq ($(shell uname),DragonFly)
++        CC = gcc
++    endif
+ endif
+ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
+     ifeq ($(USE_RPI_CROSSCOMPILER),TRUE)
+@@ -402,6 +408,7 @@ endif
+ ifeq ($(RAYLIB_BUILD_MODE),RELEASE)
+     ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
          CFLAGS += -O1
 +        CFLAGS += -fPIC
      endif
-     ifeq ($(PLATFORM),PLATFORM_ANDROID)
-         CFLAGS += -O2
+     ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
+         CFLAGS += -Os


### PR DESCRIPTION
The `freebsd.patch` did not apply cleanly as there is no longer a `ifeq ($(PLATFORM),PLATFORM_DESKTOP)` in raylib, at least in the current version I tried (vendor/raylib). Also, DragonFly still uses gcc and not clang.