### PR TITLE
Change get_key_name to return string_opt

### DIFF
--- a/src/c/raylib/core/functions.ml
+++ b/src/c/raylib/core/functions.ml
@@ -399,7 +399,7 @@ module Functions (F : Ctypes.FOREIGN) = struct
   let is_key_up = foreign "IsKeyUp" (Key.t @-> returning bool)
   let get_key_pressed = foreign "GetKeyPressed" (void @-> returning Key.t)
   let _get_char_pressed = foreign "GetCharPressed" (void @-> returning int)
-  let get_key_name = foreign "GetKeyName" (Key.t @-> returning string)
+  let get_key_name = foreign "GetKeyName" (Key.t @-> returning string_opt)
   let set_exit_key = foreign "SetExitKey" (Key.t @-> returning void)
 
   let is_gamepad_available =

--- a/src/raylib/raylib_core.mli
+++ b/src/raylib/raylib_core.mli
@@ -2058,7 +2058,7 @@ val get_char_pressed : unit -> Uchar.t
 (** [get_char_pressed ()] Get char pressed (unicode), call it multiple times for
     chars queued, returns 0 when the queue is empty*)
 
-val get_key_name : Key.t -> string
+val get_key_name : Key.t -> string option
 (** [get_key_name key] Get name of a QWERTY key on the current keyboard layout
     (eg returns string 'q' for KEY_A on an AZERTY keyboard) *)
 


### PR DESCRIPTION
This fixes #83. GetKeyName returns NULL in some cases and on some platforms. (~~Though I don't understand why I do get NULL for all keys on all platforms I tried.~~ Ah, okay, it also returns NULL unconditionally before init_window.)